### PR TITLE
Add POST /api/agent endpoint for LLM prompt interaction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,5 @@ OLLAMA_TIMEOUT=60
 
 # Set to true to run live Ollama tests (requires running Ollama instance)
 OLLAMA_TESTING=false
+
+AI_AGENT_SYSTEM_PROMPT="You are a knowledgeable nutrition assistant. Answer clearly and concisely based on established nutritional science."

--- a/.env.testing
+++ b/.env.testing
@@ -83,3 +83,5 @@ OLLAMA_TIMEOUT=60
 
 # Set to true to run live Ollama tests (requires running Ollama instance)
 OLLAMA_TESTING=true
+
+AI_AGENT_SYSTEM_PROMPT="You are a knowledgeable nutrition assistant. Answer clearly and concisely based on established nutritional science."

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -85,3 +85,5 @@ OLLAMA_TIMEOUT=60
 
 # Set to true to run live Ollama tests (requires running Ollama instance)
 OLLAMA_TESTING=false
+
+AI_AGENT_SYSTEM_PROMPT="You are a knowledgeable nutrition assistant. Answer clearly and concisely based on established nutritional science."

--- a/app/Http/Controllers/AgentController.php
+++ b/app/Http/Controllers/AgentController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\AI\Contracts\LlmClientContract;
+use App\Exceptions\LlmRequestFailedException;
+use App\Exceptions\LlmUnavailableException;
+use App\Http\Requests\AgentRequest;
+use Illuminate\Http\JsonResponse;
+
+class AgentController extends Controller
+{
+    public function ask(AgentRequest $request, LlmClientContract $llm): JsonResponse
+    {
+        $messages = [
+            ['role' => 'system', 'content' => config('ai.agent.system_prompt')],
+            ['role' => 'user',   'content' => $request->validated('prompt')],
+        ];
+
+        try {
+            $response = $llm->chat($messages);
+        } catch (LlmUnavailableException) {
+            return response()->json(
+                ['message' => 'The AI service is currently unavailable. Please try again later.'],
+                503
+            );
+        } catch (LlmRequestFailedException) {
+            return response()->json(
+                ['message' => 'The AI service returned an unexpected response.'],
+                502
+            );
+        }
+
+        return response()->json([
+            'response' => $response,
+            'model'    => config('ai.ollama.model'),
+        ]);
+    }
+}

--- a/app/Http/Requests/AgentRequest.php
+++ b/app/Http/Requests/AgentRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AgentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'prompt' => ['required', 'string', 'max:2000'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'prompt.required' => 'A prompt is required.',
+            'prompt.max'      => 'The prompt may not exceed 2000 characters.',
+        ];
+    }
+}

--- a/config/ai.php
+++ b/config/ai.php
@@ -7,6 +7,13 @@ return [
         'timeout'  => (int) env('OLLAMA_TIMEOUT', 60),
     ],
 
+    'agent' => [
+        'system_prompt' => env(
+            'AI_AGENT_SYSTEM_PROMPT',
+            'You are a knowledgeable nutrition assistant. Answer clearly and concisely based on established nutritional science.'
+        ),
+    ],
+
     'sources' => [
         // Trusted nutrition sources used by web search tools (populated in ai-tools branch)
     ],

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\AgentController;
 use App\Http\Controllers\BrandsController;
 use App\Http\Controllers\IngredientNutrientController;
 use App\Http\Controllers\IngredientsController;
@@ -83,6 +84,10 @@ Route::prefix('sources')->name('sources.')->middleware('verify.frontend')->group
     Route::post('', [SourcesController::class, 'store'])->name('store');
     Route::put('{source}', [SourcesController::class, 'update'])->name('update');
     Route::delete('{source}', [SourcesController::class, 'delete'])->name('delete');
+});
+
+Route::prefix('agent')->name('agent.')->middleware('verify.frontend')->group(function () {
+    Route::post('', [AgentController::class, 'ask'])->name('ask');
 });
 
 Route::prefix('search')->name('search')->middleware('verify.frontend')->group(function() {

--- a/tests/Feature/Agent/AgentControllerTest.php
+++ b/tests/Feature/Agent/AgentControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature\Agent;
+
+use App\AI\Contracts\LlmClientContract;
+use App\Exceptions\LlmRequestFailedException;
+use App\Exceptions\LlmUnavailableException;
+use Mockery;
+use Tests\TestCase;
+
+class AgentControllerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function mockLlm(string $returns): void
+    {
+        $mock = Mockery::mock(LlmClientContract::class);
+        $mock->shouldReceive('chat')->once()->andReturn($returns);
+        $this->app->instance(LlmClientContract::class, $mock);
+    }
+
+    private function mockLlmThrows(\Throwable $e): void
+    {
+        $mock = Mockery::mock(LlmClientContract::class);
+        $mock->shouldReceive('chat')->once()->andThrow($e);
+        $this->app->instance(LlmClientContract::class, $mock);
+    }
+
+    private function postAgent(array $data): \Illuminate\Testing\TestResponse
+    {
+        return $this->withoutMiddleware()->postJson('/api/agent', $data);
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    public function test_returns_200_with_response_and_model_on_success(): void
+    {
+        $this->mockLlm('Magnesium supports over 300 enzymatic reactions.');
+
+        $this->postAgent(['prompt' => 'What does magnesium do?'])
+            ->assertStatus(200)
+            ->assertJsonStructure(['response', 'model']);
+    }
+
+    public function test_response_contains_llm_output(): void
+    {
+        $this->mockLlm('Magnesium supports over 300 enzymatic reactions.');
+
+        $this->postAgent(['prompt' => 'What does magnesium do?'])
+            ->assertStatus(200)
+            ->assertJsonPath('response', 'Magnesium supports over 300 enzymatic reactions.')
+            ->assertJsonPath('model', config('ai.ollama.model'));
+    }
+
+    // -------------------------------------------------------------------------
+    // Error handling
+    // -------------------------------------------------------------------------
+
+    public function test_returns_503_when_llm_is_unavailable(): void
+    {
+        $this->mockLlmThrows(new LlmUnavailableException('Connection refused'));
+
+        $this->postAgent(['prompt' => 'What does magnesium do?'])
+            ->assertStatus(503)
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_returns_502_when_llm_request_fails(): void
+    {
+        $this->mockLlmThrows(new LlmRequestFailedException('Unexpected response', 500));
+
+        $this->postAgent(['prompt' => 'What does magnesium do?'])
+            ->assertStatus(502)
+            ->assertJsonStructure(['message']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation
+    // -------------------------------------------------------------------------
+
+    public function test_returns_422_when_prompt_is_missing(): void
+    {
+        $this->postAgent([])->assertStatus(422);
+    }
+
+    public function test_returns_422_when_prompt_exceeds_max_length(): void
+    {
+        $this->postAgent(['prompt' => str_repeat('a', 2001)])->assertStatus(422);
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth
+    // -------------------------------------------------------------------------
+
+    public function test_returns_401_when_unauthenticated(): void
+    {
+        $this->postJson('/api/agent', ['prompt' => 'Hello'])->assertStatus(401);
+    }
+}

--- a/tests/Feature/Agent/AgentRequestTest.php
+++ b/tests/Feature/Agent/AgentRequestTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Agent;
+
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class AgentRequestTest extends TestCase
+{
+    private function postAgent(array $data): TestResponse
+    {
+        return $this->withoutMiddleware()->postJson('/api/agent', $data);
+    }
+
+    public function test_prompt_is_required(): void
+    {
+        $this->postAgent([])->assertStatus(422)->assertJsonValidationErrors(['prompt']);
+    }
+
+    public function test_prompt_must_be_a_string(): void
+    {
+        $this->postAgent(['prompt' => 123])->assertStatus(422)->assertJsonValidationErrors(['prompt']);
+    }
+
+    public function test_prompt_cannot_exceed_2000_characters(): void
+    {
+        $this->postAgent(['prompt' => str_repeat('a', 2001)])->assertStatus(422)->assertJsonValidationErrors(['prompt']);
+    }
+
+    public function test_prompt_at_max_length_passes_validation(): void
+    {
+        $this->postAgent(['prompt' => str_repeat('a', 2000)])->assertStatus(200);
+    }
+
+    public function test_valid_prompt_passes_validation(): void
+    {
+        $this->postAgent(['prompt' => 'What are the benefits of magnesium?'])->assertStatus(200);
+    }
+}


### PR DESCRIPTION
- AgentController::ask() accepts a prompt, forwards it to Gemma via LlmClientContract::chat(), and returns the response and model name
- AgentRequest validates prompt (required, string, max 2000 characters)
- Returns 503 when Ollama is unreachable, 502 on unexpected LLM response
- Route protected by verify.frontend middleware
- config/ai.php extended with agent.system_prompt, configurable via AI_AGENT_SYSTEM_PROMPT env var