### PR TITLE
Add OpenAPI 3.0 spec via l5-swagger with PHP 8 attribute annotations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,5 @@ AI_AGENT_SYSTEM_PROMPT="You are a knowledgeable nutrition assistant. Answer clea
 
 SEARXNG_BASE_URL=http://searxng:8080
 SEARXNG_RESULT_LIMIT=10
+
+API_VERSION=1.0.0

--- a/.env.testing
+++ b/.env.testing
@@ -88,3 +88,5 @@ AI_AGENT_SYSTEM_PROMPT="You are a knowledgeable nutrition assistant. Answer clea
 
 SEARXNG_BASE_URL=http://searxng:8080
 SEARXNG_RESULT_LIMIT=10
+
+API_VERSION=1.0.0

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -90,3 +90,5 @@ AI_AGENT_SYSTEM_PROMPT="You are a knowledgeable nutrition assistant. Answer clea
 
 SEARXNG_BASE_URL=http://searxng:8080
 SEARXNG_RESULT_LIMIT=10
+
+API_VERSION=1.0.0

--- a/app/Http/Controllers/AgentController.php
+++ b/app/Http/Controllers/AgentController.php
@@ -7,9 +7,35 @@ use App\Exceptions\LlmRequestFailedException;
 use App\Exceptions\LlmUnavailableException;
 use App\Http\Requests\AgentRequest;
 use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
 
 class AgentController extends Controller
 {
+    #[OA\Post(
+        path: '/api/agent',
+        summary: 'Ask the AI nutrition agent a question',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['prompt'],
+                properties: [new OA\Property(property: 'prompt', type: 'string', example: 'What are the benefits of vitamin C?')]
+            )
+        ),
+        tags: ['Agent'],
+        responses: [
+            new OA\Response(response: 200, description: 'AI response', content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'response', type: 'string', example: 'Vitamin C is an essential nutrient...'),
+                    new OA\Property(property: 'model', type: 'string', example: 'llama3.2'),
+                ]
+            )),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+            new OA\Response(response: 502, description: 'AI service returned unexpected response'),
+            new OA\Response(response: 503, description: 'AI service unavailable'),
+        ]
+    )]
     public function ask(AgentRequest $request, AgentOrchestrator $orchestrator): JsonResponse
     {
         try {

--- a/app/Http/Controllers/BrandsController.php
+++ b/app/Http/Controllers/BrandsController.php
@@ -6,31 +6,124 @@ use App\Exceptions\BrandHasIngredientsException;
 use App\Http\Requests\BrandRequest;
 use App\Models\Brand;
 use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
 
 class BrandsController extends Controller
 {
+    #[OA\Get(
+        path: '/api/brands',
+        summary: 'List brands (paginated)',
+        security: [['frontend' => []]],
+        tags: ['Brands'],
+        parameters: [new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Paginated list of brands', content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'data', type: 'array', items: new OA\Items(ref: '#/components/schemas/Brand')),
+                    new OA\Property(property: 'current_page', type: 'integer'),
+                    new OA\Property(property: 'total', type: 'integer'),
+                    new OA\Property(property: 'per_page', type: 'integer'),
+                    new OA\Property(property: 'last_page', type: 'integer'),
+                ]
+            )),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
     public function index(): JsonResponse
     {
         return response()->json(Brand::paginate(25), 200);
     }
 
+    #[OA\Get(
+        path: '/api/brands/{brand}',
+        summary: 'Get a single brand',
+        security: [['frontend' => []]],
+        tags: ['Brands'],
+        parameters: [new OA\Parameter(name: 'brand', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Brand resource', content: new OA\JsonContent(ref: '#/components/schemas/Brand')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function show(Brand $brand): JsonResponse
     {
         return response()->json($brand->loadCount('ingredients'), 200);
     }
 
+    #[OA\Post(
+        path: '/api/brands',
+        summary: 'Create a new brand',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'Acme Foods'),
+                    new OA\Property(property: 'slug', type: 'string', nullable: true),
+                    new OA\Property(property: 'owner', type: 'string', nullable: true),
+                    new OA\Property(property: 'country', type: 'string', nullable: true),
+                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                ]
+            )
+        ),
+        tags: ['Brands'],
+        responses: [
+            new OA\Response(response: 201, description: 'Created', content: new OA\JsonContent(ref: '#/components/schemas/Brand')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function store(BrandRequest $request): JsonResponse
     {
         $brand = Brand::create($request->validated());
         return response()->json($brand, 201);
     }
 
+    #[OA\Put(
+        path: '/api/brands/{brand}',
+        summary: 'Update a brand',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'name', type: 'string'),
+                    new OA\Property(property: 'slug', type: 'string', nullable: true),
+                    new OA\Property(property: 'owner', type: 'string', nullable: true),
+                    new OA\Property(property: 'country', type: 'string', nullable: true),
+                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                ]
+            )
+        ),
+        tags: ['Brands'],
+        parameters: [new OA\Parameter(name: 'brand', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Updated', content: new OA\JsonContent(ref: '#/components/schemas/Brand')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function update(BrandRequest $request, Brand $brand): JsonResponse
     {
         $brand->update($request->validated());
         return response()->json($brand->fresh(), 200);
     }
 
+    #[OA\Delete(
+        path: '/api/brands/{brand}',
+        summary: 'Delete a brand',
+        security: [['frontend' => []]],
+        tags: ['Brands'],
+        parameters: [new OA\Parameter(name: 'brand', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 204, description: 'Deleted'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function delete(Brand $brand): JsonResponse
     {
         $brand->delete();

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,6 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use OpenApi\Attributes as OA;
+
+#[OA\Info(
+    title: 'Nutrients API',
+    version: '1.0.0',
+    description: 'REST API for managing ingredients and their nutritional data.'
+)]
+#[OA\Server(
+    url: 'http://localhost',
+    description: 'API Server'
+)]
+#[OA\SecurityScheme(
+    securityScheme: 'frontend',
+    type: 'http',
+    scheme: 'bearer',
+    description: 'Bearer token obtained from POST /api/auth/login. Also requires X-Refresh-Token, X-Application-Name, and X-Client-Url headers on every request.'
+)]
 abstract class Controller
 {
     //

--- a/app/Http/Controllers/IngredientNutrientController.php
+++ b/app/Http/Controllers/IngredientNutrientController.php
@@ -6,14 +6,50 @@ use App\Http\Requests\IngredientNutrientRequest;
 use App\Models\Ingredient;
 use App\Models\Nutrient;
 use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
 
 class IngredientNutrientController extends Controller
 {
+    #[OA\Get(
+        path: '/api/ingredients/{ingredient}/nutrients',
+        summary: 'List nutrients attached to an ingredient',
+        security: [['frontend' => []]],
+        tags: ['IngredientNutrients'],
+        parameters: [new OA\Parameter(name: 'ingredient', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Nutrient list', content: new OA\JsonContent(type: 'array', items: new OA\Items(ref: '#/components/schemas/Nutrient'))),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function index(Ingredient $ingredient): JsonResponse
     {
         return response()->json($ingredient->nutrients()->get(), 200);
     }
 
+    #[OA\Post(
+        path: '/api/ingredients/{ingredient}/nutrients/attach',
+        summary: 'Attach a nutrient to an ingredient',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['nutrient_id'],
+                properties: [
+                    new OA\Property(property: 'nutrient_id', type: 'integer', example: 1),
+                    new OA\Property(property: 'amount', type: 'number', format: 'float', nullable: true, example: 10.5),
+                    new OA\Property(property: 'amount_unit_id', type: 'integer', nullable: true),
+                ]
+            )
+        ),
+        tags: ['IngredientNutrients'],
+        parameters: [new OA\Parameter(name: 'ingredient', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Updated nutrient list', content: new OA\JsonContent(type: 'array', items: new OA\Items(ref: '#/components/schemas/Nutrient'))),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function attach(IngredientNutrientRequest $request, Ingredient $ingredient): JsonResponse
     {
         $pivot = array_filter(
@@ -28,6 +64,31 @@ class IngredientNutrientController extends Controller
         return response()->json($ingredient->nutrients()->get(), 200);
     }
 
+    #[OA\Put(
+        path: '/api/ingredients/{ingredient}/nutrients/{nutrient}',
+        summary: 'Update pivot data for a nutrient on an ingredient',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'amount', type: 'number', format: 'float', nullable: true),
+                    new OA\Property(property: 'amount_unit_id', type: 'integer', nullable: true),
+                ]
+            )
+        ),
+        tags: ['IngredientNutrients'],
+        parameters: [
+            new OA\Parameter(name: 'ingredient', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: 'nutrient', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Updated nutrient list', content: new OA\JsonContent(type: 'array', items: new OA\Items(ref: '#/components/schemas/Nutrient'))),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function updatePivot(IngredientNutrientRequest $request, Ingredient $ingredient, Nutrient $nutrient): JsonResponse
     {
         $ingredient->nutrients()->updateExistingPivot($nutrient->id, $request->validated());
@@ -35,6 +96,20 @@ class IngredientNutrientController extends Controller
         return response()->json($ingredient->nutrients()->get(), 200);
     }
 
+    #[OA\Delete(
+        path: '/api/ingredients/{ingredient}/nutrients/{nutrient}',
+        summary: 'Detach a nutrient from an ingredient',
+        security: [['frontend' => []]],
+        tags: ['IngredientNutrients'],
+        parameters: [
+            new OA\Parameter(name: 'ingredient', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: 'nutrient', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: 'Detached'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
     public function detach(Ingredient $ingredient, Nutrient $nutrient): JsonResponse
     {
         $ingredient->nutrients()->detach($nutrient->id);
@@ -42,6 +117,24 @@ class IngredientNutrientController extends Controller
         return response()->json(null, 204);
     }
 
+    #[OA\Delete(
+        path: '/api/ingredients/{ingredient}/nutrients',
+        summary: 'Detach multiple nutrients from an ingredient',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['nutrient_ids'],
+                properties: [new OA\Property(property: 'nutrient_ids', type: 'array', items: new OA\Items(type: 'integer'))]
+            )
+        ),
+        tags: ['IngredientNutrients'],
+        parameters: [new OA\Parameter(name: 'ingredient', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 204, description: 'Detached'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
     public function detachAll(IngredientNutrientRequest $request, Ingredient $ingredient): JsonResponse
     {
         $ids = $request->input('nutrient_ids');

--- a/app/Http/Controllers/IngredientsController.php
+++ b/app/Http/Controllers/IngredientsController.php
@@ -8,17 +8,49 @@ use App\Http\Requests\ResourceSearchRequest;
 use App\Http\Resources\IngredientResource;
 use App\Services\Search\SearchServiceContract;
 use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Response;
 
 class IngredientsController extends Controller
 {
     public function __construct(private SearchServiceContract $search) {}
 
+    #[OA\Get(
+        path: '/api/ingredients',
+        summary: 'List ingredients (paginated)',
+        security: [['frontend' => []]],
+        tags: ['Ingredients'],
+        parameters: [new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', example: 1))],
+        responses: [
+            new OA\Response(response: 200, description: 'Paginated list of ingredients', content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'data', type: 'array', items: new OA\Items(ref: '#/components/schemas/Ingredient')),
+                    new OA\Property(property: 'current_page', type: 'integer', example: 1),
+                    new OA\Property(property: 'total', type: 'integer', example: 500),
+                    new OA\Property(property: 'per_page', type: 'integer', example: 25),
+                    new OA\Property(property: 'last_page', type: 'integer', example: 20),
+                ]
+            )),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
     public function index(): JsonResponse
     {
         return response()->json(Ingredient::paginate(25), 200);
     }
 
+    #[OA\Get(
+        path: '/api/ingredients/{ingredient}',
+        summary: 'Get a single ingredient with all relationships',
+        security: [['frontend' => []]],
+        tags: ['Ingredients'],
+        parameters: [new OA\Parameter(name: 'ingredient', in: 'path', required: true, description: 'Ingredient ID', schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Ingredient resource', content: new OA\JsonContent(ref: '#/components/schemas/Ingredient')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function show(Ingredient $ingredient): JsonResponse
     {
         $document = $this->search->get('ingredients', $ingredient->id);
@@ -30,24 +62,120 @@ class IngredientsController extends Controller
         return response()->json(new IngredientResource($ingredient->loadForSearch()), 200);
     }
 
+    #[OA\Post(
+        path: '/api/ingredients',
+        summary: 'Create a new ingredient',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['source', 'name', 'default_amount', 'default_amount_unit_id'],
+                properties: [
+                    new OA\Property(property: 'source', type: 'string', example: 'USDA'),
+                    new OA\Property(property: 'name', type: 'string', example: 'Broccoli, raw'),
+                    new OA\Property(property: 'external_id', type: 'string', nullable: true, example: '321360'),
+                    new OA\Property(property: 'class', type: 'string', nullable: true),
+                    new OA\Property(property: 'slug', type: 'string', nullable: true, example: 'broccoli-raw'),
+                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                    new OA\Property(property: 'default_amount', type: 'number', format: 'float', example: 100.0),
+                    new OA\Property(property: 'default_amount_unit_id', type: 'integer', example: 1),
+                    new OA\Property(property: 'brand_id', type: 'integer', nullable: true),
+                ]
+            )
+        ),
+        tags: ['Ingredients'],
+        responses: [
+            new OA\Response(response: 201, description: 'Created', content: new OA\JsonContent(ref: '#/components/schemas/Ingredient')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function store(IngredientRequest $request): JsonResponse
     {
         $ingredient = Ingredient::create($request->validated());
         return response()->json($ingredient, 201);
     }
 
+    #[OA\Put(
+        path: '/api/ingredients/{ingredient}',
+        summary: 'Update an ingredient',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'source', type: 'string'),
+                    new OA\Property(property: 'name', type: 'string'),
+                    new OA\Property(property: 'external_id', type: 'string', nullable: true),
+                    new OA\Property(property: 'class', type: 'string', nullable: true),
+                    new OA\Property(property: 'slug', type: 'string', nullable: true),
+                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                    new OA\Property(property: 'default_amount', type: 'number', format: 'float'),
+                    new OA\Property(property: 'default_amount_unit_id', type: 'integer'),
+                    new OA\Property(property: 'brand_id', type: 'integer', nullable: true),
+                ]
+            )
+        ),
+        tags: ['Ingredients'],
+        parameters: [new OA\Parameter(name: 'ingredient', in: 'path', required: true, description: 'Ingredient ID', schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Updated', content: new OA\JsonContent(ref: '#/components/schemas/Ingredient')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function update(IngredientRequest $request, Ingredient $ingredient): JsonResponse
     {
         $ingredient->update($request->validated());
         return response()->json($ingredient->fresh(), 200);
     }
 
+    #[OA\Delete(
+        path: '/api/ingredients/{ingredient}',
+        summary: 'Soft-delete an ingredient',
+        security: [['frontend' => []]],
+        tags: ['Ingredients'],
+        parameters: [new OA\Parameter(name: 'ingredient', in: 'path', required: true, description: 'Ingredient ID', schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 204, description: 'Deleted'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function delete(Ingredient $ingredient): JsonResponse
     {
         $ingredient->delete();
         return response()->json(null, 204);
     }
 
+    #[OA\Post(
+        path: '/api/ingredients/search',
+        summary: 'Full-text search ingredients',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['query'],
+                properties: [
+                    new OA\Property(property: 'query', type: 'string', example: 'broccoli'),
+                    new OA\Property(property: 'page', type: 'integer', example: 1),
+                ]
+            )
+        ),
+        tags: ['Ingredients'],
+        responses: [
+            new OA\Response(response: 200, description: 'Search results', content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'hits', type: 'array', items: new OA\Items(ref: '#/components/schemas/Ingredient')),
+                    new OA\Property(property: 'total', type: 'integer', example: 3),
+                    new OA\Property(property: 'page', type: 'integer', example: 1),
+                ]
+            )),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function search(ResourceSearchRequest $request): JsonResponse
     {
         $result = $this->search->search('ingredients', $request->input('query'), 25, $request->page());

--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -8,6 +8,7 @@ use App\Services\Auth\AuthService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Http\Client\RequestException;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class LoginController extends Controller
@@ -24,12 +25,33 @@ class LoginController extends Controller
         $this->applicationUrl = request()->header('X-Client-Url') ?? null;
     }
 
+    #[OA\Post(
+        path: '/api/auth/login',
+        summary: 'Get OAuth2 redirect URI',
+        tags: ['Auth'],
+        responses: [
+            new OA\Response(response: 200, description: 'Redirect URI', content: new OA\JsonContent(
+                properties: [new OA\Property(property: 'redirect_uri', type: 'string', example: 'https://auth.example.com/oauth/authorize?...')]
+            )),
+        ]
+    )]
     public function login (): JsonResponse {
         return response()->json([
             'redirect_uri' => $this->service->login()
         ], 200);
     }
 
+    #[OA\Get(
+        path: '/api/auth/validate-access-token',
+        summary: 'Validate a bearer access token',
+        security: [['frontend' => []]],
+        tags: ['Auth'],
+        responses: [
+            new OA\Response(response: 200, description: 'Token is valid'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 503, description: 'Auth service unavailable'),
+        ]
+    )]
     public function validateAccessToken(): JsonResponse {
         if(!$this->accessToken) {
             return response()->json(['error' => 'Unauthorized'], 401);
@@ -37,7 +59,7 @@ class LoginController extends Controller
 
         try {
             $response = $this->service->validate($this->accessToken, $this->refreshToken, $this->applicationName, $this->applicationUrl);
-            
+
             if ($response->successful()) {
                 $responseData = $response->json();
                 if($responseData == true) { return response()->json("true", 200); }
@@ -53,6 +75,17 @@ class LoginController extends Controller
         }
     }
 
+    #[OA\Post(
+        path: '/api/auth/logout',
+        summary: 'Logout and invalidate tokens',
+        security: [['frontend' => []]],
+        tags: ['Auth'],
+        responses: [
+            new OA\Response(response: 200, description: 'Logged out successfully'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 503, description: 'Auth service unavailable'),
+        ]
+    )]
     public function logout(): JsonResponse {
         if (!$this->accessToken) {
             return response()->json(['error' => 'Unauthorized'], 401);

--- a/app/Http/Controllers/NutrientTagsController.php
+++ b/app/Http/Controllers/NutrientTagsController.php
@@ -7,37 +7,145 @@ use App\Models\Nutrient;
 use App\Models\NutrientTag;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
 
 class NutrientTagsController extends Controller
 {
+    #[OA\Get(
+        path: '/api/nutrient-tags',
+        summary: 'List nutrient tags (paginated)',
+        security: [['frontend' => []]],
+        tags: ['NutrientTags'],
+        parameters: [new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Paginated list of nutrient tags', content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'data', type: 'array', items: new OA\Items(ref: '#/components/schemas/NutrientTag')),
+                    new OA\Property(property: 'current_page', type: 'integer'),
+                    new OA\Property(property: 'total', type: 'integer'),
+                    new OA\Property(property: 'per_page', type: 'integer'),
+                    new OA\Property(property: 'last_page', type: 'integer'),
+                ]
+            )),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
     public function index(): JsonResponse
     {
         return response()->json(NutrientTag::paginate(25), 200);
     }
 
+    #[OA\Get(
+        path: '/api/nutrient-tags/{nutrientTag}',
+        summary: 'Get a single nutrient tag',
+        security: [['frontend' => []]],
+        tags: ['NutrientTags'],
+        parameters: [new OA\Parameter(name: 'nutrientTag', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'NutrientTag resource', content: new OA\JsonContent(ref: '#/components/schemas/NutrientTag')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function show(NutrientTag $nutrientTag): JsonResponse
     {
         return response()->json($nutrientTag, 200);
     }
 
+    #[OA\Post(
+        path: '/api/nutrient-tags',
+        summary: 'Create a new nutrient tag',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name', 'slug'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'Fat-soluble'),
+                    new OA\Property(property: 'slug', type: 'string', example: 'fat-soluble'),
+                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                ]
+            )
+        ),
+        tags: ['NutrientTags'],
+        responses: [
+            new OA\Response(response: 201, description: 'Created', content: new OA\JsonContent(ref: '#/components/schemas/NutrientTag')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function store(NutrientTagRequest $request): JsonResponse
     {
         $tag = NutrientTag::create($request->validated());
         return response()->json($tag, 201);
     }
 
+    #[OA\Put(
+        path: '/api/nutrient-tags/{nutrientTag}',
+        summary: 'Update a nutrient tag',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'name', type: 'string'),
+                    new OA\Property(property: 'slug', type: 'string'),
+                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                ]
+            )
+        ),
+        tags: ['NutrientTags'],
+        parameters: [new OA\Parameter(name: 'nutrientTag', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Updated', content: new OA\JsonContent(ref: '#/components/schemas/NutrientTag')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function update(NutrientTagRequest $request, NutrientTag $nutrientTag): JsonResponse
     {
         $nutrientTag->update($request->validated());
         return response()->json($nutrientTag->fresh(), 200);
     }
 
+    #[OA\Delete(
+        path: '/api/nutrient-tags/{nutrientTag}',
+        summary: 'Delete a nutrient tag',
+        security: [['frontend' => []]],
+        tags: ['NutrientTags'],
+        parameters: [new OA\Parameter(name: 'nutrientTag', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 204, description: 'Deleted'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function delete(NutrientTag $nutrientTag): JsonResponse
     {
         $nutrientTag->delete();
         return response()->json(null, 204);
     }
 
+    #[OA\Post(
+        path: '/api/nutrients/{nutrient}/tags',
+        summary: 'Attach a tag to a nutrient',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['tag_id'],
+                properties: [new OA\Property(property: 'tag_id', type: 'integer', example: 1)]
+            )
+        ),
+        tags: ['NutrientTags'],
+        parameters: [new OA\Parameter(name: 'nutrient', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Updated tag list', content: new OA\JsonContent(type: 'array', items: new OA\Items(ref: '#/components/schemas/NutrientTag'))),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function attach(Request $request, Nutrient $nutrient): JsonResponse
     {
         $request->validate([
@@ -49,6 +157,20 @@ class NutrientTagsController extends Controller
         return response()->json($nutrient->tags()->get(), 200);
     }
 
+    #[OA\Delete(
+        path: '/api/nutrients/{nutrient}/tags/{tag}',
+        summary: 'Detach a specific tag from a nutrient',
+        security: [['frontend' => []]],
+        tags: ['NutrientTags'],
+        parameters: [
+            new OA\Parameter(name: 'nutrient', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: 'tag', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: 'Detached'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
     public function detach(Nutrient $nutrient, NutrientTag $tag): JsonResponse
     {
         $nutrient->tags()->detach($tag->id);
@@ -56,6 +178,17 @@ class NutrientTagsController extends Controller
         return response()->json(null, 204);
     }
 
+    #[OA\Delete(
+        path: '/api/nutrients/{nutrient}/tags',
+        summary: 'Detach all tags from a nutrient',
+        security: [['frontend' => []]],
+        tags: ['NutrientTags'],
+        parameters: [new OA\Parameter(name: 'nutrient', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 204, description: 'All tags detached'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
     public function detachAll(Nutrient $nutrient): JsonResponse
     {
         $nutrient->tags()->detach();

--- a/app/Http/Controllers/NutrientsController.php
+++ b/app/Http/Controllers/NutrientsController.php
@@ -8,16 +8,48 @@ use App\Http\Requests\NutrientRequest;
 use App\Http\Requests\ResourceSearchRequest;
 use App\Http\Resources\NutrientResource;
 use App\Services\Search\SearchServiceContract;
+use OpenApi\Attributes as OA;
 
 class NutrientsController extends Controller
 {
     public function __construct(private SearchServiceContract $search) {}
 
+    #[OA\Get(
+        path: '/api/nutrients',
+        summary: 'List nutrients (paginated)',
+        security: [['frontend' => []]],
+        tags: ['Nutrients'],
+        parameters: [new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', example: 1))],
+        responses: [
+            new OA\Response(response: 200, description: 'Paginated list of nutrients', content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'data', type: 'array', items: new OA\Items(ref: '#/components/schemas/Nutrient')),
+                    new OA\Property(property: 'current_page', type: 'integer', example: 1),
+                    new OA\Property(property: 'total', type: 'integer', example: 100),
+                    new OA\Property(property: 'per_page', type: 'integer', example: 25),
+                    new OA\Property(property: 'last_page', type: 'integer', example: 4),
+                ]
+            )),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
     public function index(): JsonResponse
     {
         return response()->json(Nutrient::paginate(25), 200);
     }
 
+    #[OA\Get(
+        path: '/api/nutrients/{nutrient}',
+        summary: 'Get a single nutrient with all relationships',
+        security: [['frontend' => []]],
+        tags: ['Nutrients'],
+        parameters: [new OA\Parameter(name: 'nutrient', in: 'path', required: true, description: 'Nutrient ID', schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Nutrient resource', content: new OA\JsonContent(ref: '#/components/schemas/Nutrient')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function show(Nutrient $nutrient): JsonResponse
     {
         $document = $this->search->get('nutrients', $nutrient->id);
@@ -29,24 +61,122 @@ class NutrientsController extends Controller
         return response()->json(new NutrientResource($nutrient->loadForSearch()), 200);
     }
 
+    #[OA\Post(
+        path: '/api/nutrients',
+        summary: 'Create a new nutrient',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['source_id', 'name'],
+                properties: [
+                    new OA\Property(property: 'source_id', type: 'integer', example: 1),
+                    new OA\Property(property: 'name', type: 'string', example: 'Vitamin C'),
+                    new OA\Property(property: 'external_id', type: 'string', nullable: true, example: '1004'),
+                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                    new OA\Property(property: 'parent_id', type: 'integer', nullable: true),
+                    new OA\Property(property: 'slug', type: 'string', nullable: true, example: 'vitamin-c'),
+                    new OA\Property(property: 'canonical_unit_id', type: 'integer', nullable: true),
+                    new OA\Property(property: 'iu_to_canonical_factor', type: 'number', format: 'float', nullable: true),
+                    new OA\Property(property: 'is_label_standard', type: 'boolean', example: true),
+                    new OA\Property(property: 'display_order', type: 'integer', nullable: true),
+                ]
+            )
+        ),
+        tags: ['Nutrients'],
+        responses: [
+            new OA\Response(response: 201, description: 'Created', content: new OA\JsonContent(ref: '#/components/schemas/Nutrient')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function store(NutrientRequest $request): JsonResponse
     {
         $nutrient = Nutrient::create($request->validated());
         return response()->json($nutrient, 201);
     }
 
+    #[OA\Put(
+        path: '/api/nutrients/{nutrient}',
+        summary: 'Update a nutrient',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'source_id', type: 'integer'),
+                    new OA\Property(property: 'name', type: 'string'),
+                    new OA\Property(property: 'external_id', type: 'string', nullable: true),
+                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                    new OA\Property(property: 'parent_id', type: 'integer', nullable: true),
+                    new OA\Property(property: 'slug', type: 'string', nullable: true),
+                    new OA\Property(property: 'canonical_unit_id', type: 'integer', nullable: true),
+                    new OA\Property(property: 'iu_to_canonical_factor', type: 'number', format: 'float', nullable: true),
+                    new OA\Property(property: 'is_label_standard', type: 'boolean'),
+                    new OA\Property(property: 'display_order', type: 'integer', nullable: true),
+                ]
+            )
+        ),
+        tags: ['Nutrients'],
+        parameters: [new OA\Parameter(name: 'nutrient', in: 'path', required: true, description: 'Nutrient ID', schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Updated', content: new OA\JsonContent(ref: '#/components/schemas/Nutrient')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function update(NutrientRequest $request, Nutrient $nutrient): JsonResponse
     {
         $nutrient->update($request->validated());
         return response()->json($nutrient->fresh(), 200);
     }
 
+    #[OA\Delete(
+        path: '/api/nutrients/{nutrient}',
+        summary: 'Soft-delete a nutrient',
+        security: [['frontend' => []]],
+        tags: ['Nutrients'],
+        parameters: [new OA\Parameter(name: 'nutrient', in: 'path', required: true, description: 'Nutrient ID', schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 204, description: 'Deleted'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function delete(Nutrient $nutrient): JsonResponse
     {
         $nutrient->delete();
         return response()->json(null, 204);
     }
 
+    #[OA\Post(
+        path: '/api/nutrients/search',
+        summary: 'Full-text search nutrients',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['query'],
+                properties: [
+                    new OA\Property(property: 'query', type: 'string', example: 'vitamin c'),
+                    new OA\Property(property: 'page', type: 'integer', example: 1),
+                ]
+            )
+        ),
+        tags: ['Nutrients'],
+        responses: [
+            new OA\Response(response: 200, description: 'Search results', content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'hits', type: 'array', items: new OA\Items(ref: '#/components/schemas/Nutrient')),
+                    new OA\Property(property: 'total', type: 'integer', example: 5),
+                    new OA\Property(property: 'page', type: 'integer', example: 1),
+                ]
+            )),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function search(ResourceSearchRequest $request): JsonResponse
     {
         $result = $this->search->search('nutrients', $request->input('query'), 25, $request->page());

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Http\Requests\SearchRequest;
 use Illuminate\Support\Facades\Cache;
 use App\Services\Search\SearchServiceContract;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class SearchController extends Controller
@@ -18,7 +19,36 @@ class SearchController extends Controller
     {
         $this->searchService = $searchService;
     }
-    
+
+    #[OA\Post(
+        path: '/api/search',
+        summary: 'Full-text search across a resource index with caching',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['query', 'index'],
+                properties: [
+                    new OA\Property(property: 'query', type: 'string', example: 'broccoli'),
+                    new OA\Property(property: 'index', type: 'string', example: 'ingredients', description: 'Search index name (e.g. ingredients, nutrients)'),
+                    new OA\Property(property: 'page', type: 'integer', example: 1),
+                ]
+            )
+        ),
+        tags: ['Search'],
+        responses: [
+            new OA\Response(response: 200, description: 'Search results', content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'hits', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'total', type: 'integer', example: 10),
+                    new OA\Property(property: 'page', type: 'integer', example: 1),
+                ]
+            )),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+            new OA\Response(response: 502, description: 'Search service unavailable'),
+        ]
+    )]
     public function search(SearchRequest $request): JsonResponse
     {
         $data = $request->validated();

--- a/app/Http/Controllers/SourcesController.php
+++ b/app/Http/Controllers/SourcesController.php
@@ -5,31 +5,122 @@ namespace App\Http\Controllers;
 use App\Http\Requests\SourceRequest;
 use App\Models\Source;
 use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
 
 class SourcesController extends Controller
 {
+    #[OA\Get(
+        path: '/api/sources',
+        summary: 'List sources (paginated)',
+        security: [['frontend' => []]],
+        tags: ['Sources'],
+        parameters: [new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Paginated list of sources', content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'data', type: 'array', items: new OA\Items(ref: '#/components/schemas/Source')),
+                    new OA\Property(property: 'current_page', type: 'integer'),
+                    new OA\Property(property: 'total', type: 'integer'),
+                    new OA\Property(property: 'per_page', type: 'integer'),
+                    new OA\Property(property: 'last_page', type: 'integer'),
+                ]
+            )),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
     public function index(): JsonResponse
     {
         return response()->json(Source::paginate(25), 200);
     }
 
+    #[OA\Get(
+        path: '/api/sources/{source}',
+        summary: 'Get a single source',
+        security: [['frontend' => []]],
+        tags: ['Sources'],
+        parameters: [new OA\Parameter(name: 'source', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Source resource', content: new OA\JsonContent(ref: '#/components/schemas/Source')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function show(Source $source): JsonResponse
     {
         return response()->json($source, 200);
     }
 
+    #[OA\Post(
+        path: '/api/sources',
+        summary: 'Create a new source',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name', 'slug'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'USDA FoodData Central'),
+                    new OA\Property(property: 'slug', type: 'string', example: 'usda-fooddata-central'),
+                    new OA\Property(property: 'url', type: 'string', nullable: true),
+                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                ]
+            )
+        ),
+        tags: ['Sources'],
+        responses: [
+            new OA\Response(response: 201, description: 'Created', content: new OA\JsonContent(ref: '#/components/schemas/Source')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function store(SourceRequest $request): JsonResponse
     {
         $source = Source::create($request->validated());
         return response()->json($source, 201);
     }
 
+    #[OA\Put(
+        path: '/api/sources/{source}',
+        summary: 'Update a source',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'name', type: 'string'),
+                    new OA\Property(property: 'slug', type: 'string'),
+                    new OA\Property(property: 'url', type: 'string', nullable: true),
+                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                ]
+            )
+        ),
+        tags: ['Sources'],
+        parameters: [new OA\Parameter(name: 'source', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Updated', content: new OA\JsonContent(ref: '#/components/schemas/Source')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function update(SourceRequest $request, Source $source): JsonResponse
     {
         $source->update($request->validated());
         return response()->json($source->fresh(), 200);
     }
 
+    #[OA\Delete(
+        path: '/api/sources/{source}',
+        summary: 'Delete a source',
+        security: [['frontend' => []]],
+        tags: ['Sources'],
+        parameters: [new OA\Parameter(name: 'source', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 204, description: 'Deleted'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function delete(Source $source): JsonResponse
     {
         $source->delete();

--- a/app/Http/Controllers/UnitsController.php
+++ b/app/Http/Controllers/UnitsController.php
@@ -5,31 +5,124 @@ namespace App\Http\Controllers;
 use App\Models\Unit;
 use Illuminate\Http\JsonResponse;
 use App\Http\Requests\UnitRequest;
+use OpenApi\Attributes as OA;
 
 class UnitsController extends Controller
 {
+    #[OA\Get(
+        path: '/api/units',
+        summary: 'List units (paginated)',
+        security: [['frontend' => []]],
+        tags: ['Units'],
+        parameters: [new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Paginated list of units', content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'data', type: 'array', items: new OA\Items(ref: '#/components/schemas/Unit')),
+                    new OA\Property(property: 'current_page', type: 'integer'),
+                    new OA\Property(property: 'total', type: 'integer'),
+                    new OA\Property(property: 'per_page', type: 'integer'),
+                    new OA\Property(property: 'last_page', type: 'integer'),
+                ]
+            )),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
     public function index(): JsonResponse
     {
         return response()->json(Unit::paginate(25), 200);
     }
 
+    #[OA\Get(
+        path: '/api/units/{unit}',
+        summary: 'Get a single unit with base and derived units',
+        security: [['frontend' => []]],
+        tags: ['Units'],
+        parameters: [new OA\Parameter(name: 'unit', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Unit resource', content: new OA\JsonContent(ref: '#/components/schemas/Unit')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function show(Unit $unit): JsonResponse
     {
         return response()->json($unit->load(['baseUnit', 'derivedUnits']), 200);
     }
 
+    #[OA\Post(
+        path: '/api/units',
+        summary: 'Create a new unit',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name', 'abbreviation'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'Gram'),
+                    new OA\Property(property: 'abbreviation', type: 'string', example: 'g'),
+                    new OA\Property(property: 'type', type: 'string', nullable: true, example: 'mass'),
+                    new OA\Property(property: 'to_base_factor', type: 'number', format: 'float', nullable: true, example: 1.0),
+                    new OA\Property(property: 'base_unit_id', type: 'integer', nullable: true),
+                ]
+            )
+        ),
+        tags: ['Units'],
+        responses: [
+            new OA\Response(response: 201, description: 'Created', content: new OA\JsonContent(ref: '#/components/schemas/Unit')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function store(UnitRequest $request): JsonResponse
     {
         $unit = Unit::create($request->validated());
         return response()->json($unit, 201);
     }
 
+    #[OA\Put(
+        path: '/api/units/{unit}',
+        summary: 'Update a unit',
+        security: [['frontend' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'name', type: 'string'),
+                    new OA\Property(property: 'abbreviation', type: 'string'),
+                    new OA\Property(property: 'type', type: 'string', nullable: true),
+                    new OA\Property(property: 'to_base_factor', type: 'number', format: 'float', nullable: true),
+                    new OA\Property(property: 'base_unit_id', type: 'integer', nullable: true),
+                ]
+            )
+        ),
+        tags: ['Units'],
+        parameters: [new OA\Parameter(name: 'unit', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 200, description: 'Updated', content: new OA\JsonContent(ref: '#/components/schemas/Unit')),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
     public function update(UnitRequest $request, Unit $unit): JsonResponse
     {
         $unit->update($request->validated());
         return response()->json($unit->fresh(), 200);
     }
 
+    #[OA\Delete(
+        path: '/api/units/{unit}',
+        summary: 'Delete a unit',
+        security: [['frontend' => []]],
+        tags: ['Units'],
+        parameters: [new OA\Parameter(name: 'unit', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))],
+        responses: [
+            new OA\Response(response: 204, description: 'Deleted'),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
     public function delete(Unit $unit): JsonResponse
     {
         $unit->delete();

--- a/app/Http/Resources/BrandResource.php
+++ b/app/Http/Resources/BrandResource.php
@@ -4,7 +4,22 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Attributes as OA;
 
+#[OA\Schema(
+    schema: 'Brand',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'name', type: 'string', example: 'Acme Foods'),
+        new OA\Property(property: 'slug', type: 'string', example: 'acme-foods'),
+        new OA\Property(property: 'owner', type: 'string', nullable: true, example: 'Acme Corp'),
+        new OA\Property(property: 'country', type: 'string', nullable: true, example: 'US'),
+        new OA\Property(property: 'description', type: 'string', nullable: true, example: null),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+    ]
+)]
 class BrandResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/IngredientCategoryResource.php
+++ b/app/Http/Resources/IngredientCategoryResource.php
@@ -4,7 +4,18 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Attributes as OA;
 
+#[OA\Schema(
+    schema: 'IngredientCategory',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'name', type: 'string', example: 'Vegetables'),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+    ]
+)]
 class IngredientCategoryResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/IngredientNutrientPivotResource.php
+++ b/app/Http/Resources/IngredientNutrientPivotResource.php
@@ -4,7 +4,18 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Attributes as OA;
 
+#[OA\Schema(
+    schema: 'IngredientNutrientPivot',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'amount', type: 'number', format: 'float', nullable: true, example: 10.5),
+        new OA\Property(property: 'amount_unit', ref: '#/components/schemas/Unit', nullable: true),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+    ]
+)]
 class IngredientNutrientPivotResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/IngredientNutritionFactResource.php
+++ b/app/Http/Resources/IngredientNutritionFactResource.php
@@ -4,7 +4,21 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Attributes as OA;
 
+#[OA\Schema(
+    schema: 'IngredientNutritionFact',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'category', type: 'string', nullable: true, example: 'Vitamins'),
+        new OA\Property(property: 'name', type: 'string', example: 'Vitamin C'),
+        new OA\Property(property: 'amount', type: 'number', format: 'float', nullable: true, example: 52.0),
+        new OA\Property(property: 'unit', ref: '#/components/schemas/Unit', nullable: true),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+    ]
+)]
 class IngredientNutritionFactResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/IngredientResource.php
+++ b/app/Http/Resources/IngredientResource.php
@@ -4,7 +4,43 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Attributes as OA;
 
+#[OA\Schema(
+    schema: 'Ingredient',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'external_id', type: 'string', nullable: true, example: '321360'),
+        new OA\Property(property: 'source', type: 'string', nullable: true, example: 'USDA'),
+        new OA\Property(property: 'class', type: 'string', nullable: true, example: 'FoodItem'),
+        new OA\Property(property: 'name', type: 'string', example: 'Broccoli, raw'),
+        new OA\Property(property: 'slug', type: 'string', example: 'broccoli-raw'),
+        new OA\Property(property: 'description', type: 'string', nullable: true, example: null),
+        new OA\Property(property: 'default_amount', type: 'number', format: 'float', nullable: true, example: 100.0),
+        new OA\Property(property: 'sync_status', type: 'string', example: 'synced'),
+        new OA\Property(property: 'brand', ref: '#/components/schemas/Brand', nullable: true),
+        new OA\Property(property: 'default_amount_unit', ref: '#/components/schemas/Unit', nullable: true),
+        new OA\Property(
+            property: 'nutrients',
+            type: 'array',
+            nullable: true,
+            items: new OA\Items(
+                allOf: [
+                    new OA\Schema(ref: '#/components/schemas/Nutrient'),
+                    new OA\Schema(properties: [
+                        new OA\Property(property: 'pivot', ref: '#/components/schemas/IngredientNutrientPivot'),
+                    ]),
+                ]
+            )
+        ),
+        new OA\Property(property: 'nutrition_facts', type: 'array', nullable: true, items: new OA\Items(ref: '#/components/schemas/IngredientNutritionFact')),
+        new OA\Property(property: 'categories', type: 'array', nullable: true, items: new OA\Items(ref: '#/components/schemas/IngredientCategory')),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'deleted_at', type: 'string', format: 'date-time', nullable: true),
+    ]
+)]
 class IngredientResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/NutrientResource.php
+++ b/app/Http/Resources/NutrientResource.php
@@ -4,7 +4,31 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Attributes as OA;
 
+#[OA\Schema(
+    schema: 'Nutrient',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'external_id', type: 'string', nullable: true, example: '1004'),
+        new OA\Property(property: 'name', type: 'string', example: 'Vitamin C'),
+        new OA\Property(property: 'description', type: 'string', nullable: true, example: null),
+        new OA\Property(property: 'slug', type: 'string', example: 'vitamin-c'),
+        new OA\Property(property: 'iu_to_canonical_factor', type: 'number', format: 'float', nullable: true, example: null),
+        new OA\Property(property: 'is_label_standard', type: 'boolean', example: true),
+        new OA\Property(property: 'display_order', type: 'integer', nullable: true, example: 10),
+        new OA\Property(property: 'sync_status', type: 'string', example: 'synced'),
+        new OA\Property(property: 'source', ref: '#/components/schemas/Source', nullable: true),
+        new OA\Property(property: 'canonical_unit', ref: '#/components/schemas/Unit', nullable: true),
+        new OA\Property(property: 'parent', ref: '#/components/schemas/Nutrient', nullable: true),
+        new OA\Property(property: 'children', type: 'array', items: new OA\Items(ref: '#/components/schemas/Nutrient')),
+        new OA\Property(property: 'tags', type: 'array', items: new OA\Items(ref: '#/components/schemas/NutrientTag')),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'deleted_at', type: 'string', format: 'date-time', nullable: true),
+    ]
+)]
 class NutrientResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/NutrientTagResource.php
+++ b/app/Http/Resources/NutrientTagResource.php
@@ -4,7 +4,20 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Attributes as OA;
 
+#[OA\Schema(
+    schema: 'NutrientTag',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'name', type: 'string', example: 'Fat-soluble'),
+        new OA\Property(property: 'slug', type: 'string', example: 'fat-soluble'),
+        new OA\Property(property: 'description', type: 'string', nullable: true, example: null),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+    ]
+)]
 class NutrientTagResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/SourceResource.php
+++ b/app/Http/Resources/SourceResource.php
@@ -4,7 +4,21 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Attributes as OA;
 
+#[OA\Schema(
+    schema: 'Source',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'name', type: 'string', example: 'USDA FoodData Central'),
+        new OA\Property(property: 'slug', type: 'string', example: 'usda-fooddata-central'),
+        new OA\Property(property: 'url', type: 'string', nullable: true, example: 'https://fdc.nal.usda.gov'),
+        new OA\Property(property: 'description', type: 'string', nullable: true, example: null),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+    ]
+)]
 class SourceResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/UnitResource.php
+++ b/app/Http/Resources/UnitResource.php
@@ -4,7 +4,22 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Attributes as OA;
 
+#[OA\Schema(
+    schema: 'Unit',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'name', type: 'string', example: 'Gram'),
+        new OA\Property(property: 'abbreviation', type: 'string', example: 'g'),
+        new OA\Property(property: 'type', type: 'string', nullable: true, example: 'mass'),
+        new OA\Property(property: 'to_base_factor', type: 'number', format: 'float', nullable: true, example: 1.0),
+        new OA\Property(property: 'base_unit_id', type: 'integer', nullable: true, example: null),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+    ]
+)]
 class UnitResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,8 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "darkaonline/l5-swagger": "^11.0",
+        "doctrine/annotations": "^2.0",
         "doctrine/dbal": "^4.3",
         "halaxa/json-machine": "^1.2",
         "laravel/framework": "^12.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcf0b26e8d40e28dedc4a057ec945d8e",
+    "content-hash": "ded1267d6774d10b7fbe8c1327643722",
     "packages": [
         {
             "name": "brick/math",
@@ -134,6 +134,86 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "darkaonline/l5-swagger",
+            "version": "11.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "63d737e841533cac6e8c04a007561aa833f69f3a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/63d737e841533cac6e8c04a007561aa833f69f3a",
+                "reference": "63d737e841533cac6e8c04a007561aa833f69f3a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laravel/framework": "^13.0 || ^12.1 || ^11.44",
+                "php": "^8.2",
+                "swagger-api/swagger-ui": ">=5.18.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "zircote/swagger-php": "^6.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^11.0 || ^10.0 || ^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    },
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/11.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-08T13:14:00+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -276,6 +356,83 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.10.28",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6.4 || ^7",
+                "vimeo/psalm": "^4.30 || ^5.14"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
+            },
+            "abandoned": true,
+            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -3743,6 +3900,53 @@
             "time": "2025-06-26T16:29:55+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
             "name": "psr/cache",
             "version": "3.0.0",
             "source": {
@@ -4395,6 +4599,68 @@
             "time": "2025-08-04T12:39:37+00:00"
         },
         {
+            "name": "radebatz/type-info-extras",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DerManoMann/type-info-extras.git",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DerManoMann/type-info-extras/zipball/95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "symfony/type-info": "^7.3.8 || ^7.4.1 || ^8.0 || ^8.1-@dev"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.70",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Radebatz\\TypeInfoExtras\\": "src"
+                },
+                "exclude-from-classmap": [
+                    "/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.org"
+                }
+            ],
+            "description": "Extras for symfony/type-info",
+            "homepage": "http://radebatz.net/mano/",
+            "keywords": [
+                "component",
+                "symfony",
+                "type-info",
+                "types"
+            ],
+            "support": {
+                "issues": "https://github.com/DerManoMann/type-info-extras/issues",
+                "source": "https://github.com/DerManoMann/type-info-extras/tree/1.0.7"
+            },
+            "time": "2026-03-06T22:40:29+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -4591,6 +4857,67 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.1"
             },
             "time": "2025-09-04T20:59:21+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.32.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "dcb493cdbf58fa885047513bd176a644f92c4955"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/dcb493cdbf58fa885047513bd176a644f92c4955",
+                "reference": "dcb493cdbf58fa885047513bd176a644f92c4955",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.32.5"
+            },
+            "time": "2026-04-27T12:54:38+00:00"
         },
         {
             "name": "symfony/clock",
@@ -7069,6 +7396,89 @@
             "time": "2024-09-27T08:32:26+00:00"
         },
         {
+            "name": "symfony/type-info",
+            "version": "v7.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "cafeedbf157b890e94ac5b83eaed85595106d5d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/cafeedbf157b890e94ac5b83eaed85595106d5d6",
+                "reference": "cafeedbf157b890e94ac5b83eaed85595106d5d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v7.4.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-22T15:21:55+00:00"
+        },
+        {
             "name": "symfony/uid",
             "version": "v7.3.1",
             "source": {
@@ -7228,6 +7638,82 @@
                 }
             ],
             "time": "2025-08-13T11:49:31+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-27T11:34:33+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -7499,6 +7985,96 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "6.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "9447c1f45b5ae93185caea9a0c8e298399188a25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/9447c1f45b5ae93185caea9a0c8e298399188a25",
+                "reference": "9447c1f45b5ae93185caea9a0c8e298399188a25",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "nikic/php-parser": "^4.19 || ^5.0",
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "radebatz/type-info-extras": "^1.0.2",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "symfony/process": ">=6, <6.4.14"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5",
+                "rector/rector": "^2.3.1"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "Generate interactive documentation for your RESTful API using PHP attributes (preferred) or PHPDoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/6.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zircote",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-28T06:42:58+00:00"
         }
     ],
     "packages-dev": [
@@ -9727,82 +10303,6 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v7.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<6.4"
-            },
-            "require-dev": {
-                "symfony/console": "^6.4|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-27T11:34:33+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/app.php
+++ b/config/app.php
@@ -15,6 +15,8 @@ return [
 
     'name' => env('APP_NAME', 'Laravel'),
 
+    'api_version' => env('API_VERSION', '1.0.0'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Environment

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,0 +1,256 @@
+<?php
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'Nutrients API',
+            ],
+
+            'routes' => [
+                'api' => 'api/docs',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                 */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
+                 * File name of the generated json documentation file
+                 */
+                'docs_json' => 'openapi.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                 */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                 * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                 */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                 */
+                'annotations' => [
+                    base_path('app'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+             */
+            'docs' => 'api/docs/openapi.json',
+
+            /*
+             * Route for Oauth2 authentication callback.
+             */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+             */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+             */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+             */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+             */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+             */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+             */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php.
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+            /** Example */
+            /**
+             * 'operationId.hash' => true,
+             * 'pathFilter' => [
+             * 'tags' => [
+             * '/pets/',
+             * '/store/',
+             * ],
+             * ],.
+             */
+            ],
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+             */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [],
+            'security'        => [],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+         */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+         */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+         */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+         */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+         */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+         */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+         */
+        'ui' => [
+            'display' => [
+                'dark_mode' => env('L5_SWAGGER_UI_DARK_MODE', false),
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                     * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                     */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST'    => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+            'L5_SWAGGER_CONST_VERSION' => env('API_VERSION', '1.0.0'),
+        ],
+    ],
+];

--- a/resources/views/vendor/l5-swagger/index.blade.php
+++ b/resources/views/vendor/l5-swagger/index.blade.php
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ $documentationTitle }}</title>
+    <link rel="stylesheet" type="text/css" href="{{ l5_swagger_asset($documentation, 'swagger-ui.css') }}">
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-32x32.png') }}" sizes="32x32"/>
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-16x16.png') }}" sizes="16x16"/>
+    <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+    </style>
+    @if(config('l5-swagger.defaults.ui.display.dark_mode'))
+        <style>
+            body#dark-mode,
+            #dark-mode .scheme-container {
+                background: #1b1b1b;
+            }
+            #dark-mode .scheme-container,
+            #dark-mode .opblock .opblock-section-header{
+                box-shadow: 0 1px 2px 0 rgba(255, 255, 255, 0.15);
+            }
+            #dark-mode .operation-filter-input,
+            #dark-mode .dialog-ux .modal-ux,
+            #dark-mode input[type=email],
+            #dark-mode input[type=file],
+            #dark-mode input[type=password],
+            #dark-mode input[type=search],
+            #dark-mode input[type=text],
+            #dark-mode textarea{
+                background: #343434;
+                color: #e7e7e7;
+            }
+            #dark-mode .title,
+            #dark-mode li,
+            #dark-mode p,
+            #dark-mode table,
+            #dark-mode label,
+            #dark-mode .opblock-tag,
+            #dark-mode .opblock .opblock-summary-operation-id,
+            #dark-mode .opblock .opblock-summary-path,
+            #dark-mode .opblock .opblock-summary-path__deprecated,
+            #dark-mode h1,
+            #dark-mode h2,
+            #dark-mode h3,
+            #dark-mode h4,
+            #dark-mode h5,
+            #dark-mode .btn,
+            #dark-mode .tab li,
+            #dark-mode .parameter__name,
+            #dark-mode .parameter__type,
+            #dark-mode .prop-format,
+            #dark-mode .loading-container .loading:after{
+                color: #e7e7e7;
+            }
+            #dark-mode .opblock-description-wrapper p,
+            #dark-mode .opblock-external-docs-wrapper p,
+            #dark-mode .opblock-title_normal p,
+            #dark-mode .response-col_status,
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th,
+            #dark-mode .response-col_links,
+            #dark-mode .swagger-ui{
+                color: wheat;
+            }
+            #dark-mode .parameter__extension,
+            #dark-mode .parameter__in,
+            #dark-mode .model-title{
+                color: #949494;
+            }
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th{
+                border-color: rgba(120,120,120,.2);
+            }
+            #dark-mode .opblock .opblock-section-header{
+                background: transparent;
+            }
+            #dark-mode .opblock.opblock-post{
+                background: rgba(73,204,144,.25);
+            }
+            #dark-mode .opblock.opblock-get{
+                background: rgba(97,175,254,.25);
+            }
+            #dark-mode .opblock.opblock-put{
+                background: rgba(252,161,48,.25);
+            }
+            #dark-mode .opblock.opblock-delete{
+                background: rgba(249,62,62,.25);
+            }
+            #dark-mode .loading-container .loading:before{
+                border-color: rgba(255,255,255,10%);
+                border-top-color: rgba(255,255,255,.6);
+            }
+            #dark-mode svg:not(:root){
+                fill: #e7e7e7;
+            }
+            #dark-mode .opblock-summary-description {
+                color: #fafafa;
+            }
+        </style>
+    @endif
+</head>
+
+<body @if(config('l5-swagger.defaults.ui.display.dark_mode')) id="dark-mode" @endif>
+<div id="swagger-ui"></div>
+
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-bundle.js') }}"></script>
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-standalone-preset.js') }}"></script>
+<script>
+    window.onload = function() {
+        const urls = [];
+
+        @foreach($urlsToDocs as $title => $url)
+            urls.push({name: "{{ $title }}", url: "{{ $url }}"});
+        @endforeach
+
+        // Build a system
+        const ui = SwaggerUIBundle({
+            dom_id: '#swagger-ui',
+            urls: urls,
+            "urls.primaryName": "{{ $documentationTitle }}",
+            operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
+            configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
+            validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+            oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback', [], $useAbsolutePath) }}",
+
+            requestInterceptor: function(request) {
+                request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                return request;
+            },
+
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+
+            layout: "StandaloneLayout",
+            docExpansion : "{!! config('l5-swagger.defaults.ui.display.doc_expansion', 'none') !!}",
+            deepLinking: true,
+            filter: {!! config('l5-swagger.defaults.ui.display.filter') ? 'true' : 'false' !!},
+            persistAuthorization: "{!! config('l5-swagger.defaults.ui.authorization.persist_authorization') ? 'true' : 'false' !!}",
+
+        })
+
+        window.ui = ui
+
+        @if(in_array('oauth2', array_column(config('l5-swagger.defaults.securityDefinitions.securitySchemes'), 'type')))
+        ui.initOAuth({
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.oauth2.use_pkce_with_authorization_code_grant') !!}"
+        })
+        @endif
+    }
+</script>
+</body>
+</html>

--- a/storage/api-docs/openapi.json
+++ b/storage/api-docs/openapi.json
@@ -1,0 +1,3005 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Nutrients API",
+        "description": "REST API for managing ingredients and their nutritional data.",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost",
+            "description": "API Server"
+        }
+    ],
+    "paths": {
+        "/api/agent": {
+            "post": {
+                "tags": [
+                    "Agent"
+                ],
+                "summary": "Ask the AI nutrition agent a question",
+                "operationId": "34eb8cbb34df32b7e944b04631bad5ef",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "prompt"
+                                ],
+                                "properties": {
+                                    "prompt": {
+                                        "type": "string",
+                                        "example": "What are the benefits of vitamin C?"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "AI response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "response": {
+                                            "type": "string",
+                                            "example": "Vitamin C is an essential nutrient..."
+                                        },
+                                        "model": {
+                                            "type": "string",
+                                            "example": "llama3.2"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    },
+                    "502": {
+                        "description": "AI service returned unexpected response"
+                    },
+                    "503": {
+                        "description": "AI service unavailable"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/brands": {
+            "get": {
+                "tags": [
+                    "Brands"
+                ],
+                "summary": "List brands (paginated)",
+                "operationId": "02dade6ef73b43ec83bd6c207f453017",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Paginated list of brands",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Brand"
+                                            }
+                                        },
+                                        "current_page": {
+                                            "type": "integer"
+                                        },
+                                        "total": {
+                                            "type": "integer"
+                                        },
+                                        "per_page": {
+                                            "type": "integer"
+                                        },
+                                        "last_page": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Brands"
+                ],
+                "summary": "Create a new brand",
+                "operationId": "e33aeeffdf4a6ebca0d467f3125c4c2e",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Acme Foods"
+                                    },
+                                    "slug": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "owner": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "country": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Brand"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/brands/{brand}": {
+            "get": {
+                "tags": [
+                    "Brands"
+                ],
+                "summary": "Get a single brand",
+                "operationId": "50441dc20d5f060caae0a11c6222868a",
+                "parameters": [
+                    {
+                        "name": "brand",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Brand resource",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Brand"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Brands"
+                ],
+                "summary": "Update a brand",
+                "operationId": "7a48c164be636d6b3d81d03f0d843e1d",
+                "parameters": [
+                    {
+                        "name": "brand",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "slug": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "owner": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "country": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Brand"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Brands"
+                ],
+                "summary": "Delete a brand",
+                "operationId": "8f928c6be1394a8a64a728308e26817b",
+                "parameters": [
+                    {
+                        "name": "brand",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Deleted"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/ingredients/{ingredient}/nutrients": {
+            "get": {
+                "tags": [
+                    "IngredientNutrients"
+                ],
+                "summary": "List nutrients attached to an ingredient",
+                "operationId": "c4110bc2112c2eb8304574f751d787f9",
+                "parameters": [
+                    {
+                        "name": "ingredient",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Nutrient list",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Nutrient"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "IngredientNutrients"
+                ],
+                "summary": "Detach multiple nutrients from an ingredient",
+                "operationId": "1405d8b366e16faedc5009397c32e4f8",
+                "parameters": [
+                    {
+                        "name": "ingredient",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "nutrient_ids"
+                                ],
+                                "properties": {
+                                    "nutrient_ids": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Detached"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/ingredients/{ingredient}/nutrients/attach": {
+            "post": {
+                "tags": [
+                    "IngredientNutrients"
+                ],
+                "summary": "Attach a nutrient to an ingredient",
+                "operationId": "3d008aefee89333d24eb8baaac2144f4",
+                "parameters": [
+                    {
+                        "name": "ingredient",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "nutrient_id"
+                                ],
+                                "properties": {
+                                    "nutrient_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "amount": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 10.5,
+                                        "nullable": true
+                                    },
+                                    "amount_unit_id": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated nutrient list",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Nutrient"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/ingredients/{ingredient}/nutrients/{nutrient}": {
+            "put": {
+                "tags": [
+                    "IngredientNutrients"
+                ],
+                "summary": "Update pivot data for a nutrient on an ingredient",
+                "operationId": "1a75e9333eef06f9eebefacb6329a5a4",
+                "parameters": [
+                    {
+                        "name": "ingredient",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "nutrient",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "amount": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "nullable": true
+                                    },
+                                    "amount_unit_id": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated nutrient list",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Nutrient"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "IngredientNutrients"
+                ],
+                "summary": "Detach a nutrient from an ingredient",
+                "operationId": "f6719f327d40027f24c94e66ab1907e5",
+                "parameters": [
+                    {
+                        "name": "ingredient",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "nutrient",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Detached"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/ingredients": {
+            "get": {
+                "tags": [
+                    "Ingredients"
+                ],
+                "summary": "List ingredients (paginated)",
+                "operationId": "5d595349bcfde36b13640a043eb2db57",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Paginated list of ingredients",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Ingredient"
+                                            }
+                                        },
+                                        "current_page": {
+                                            "type": "integer",
+                                            "example": 1
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "example": 500
+                                        },
+                                        "per_page": {
+                                            "type": "integer",
+                                            "example": 25
+                                        },
+                                        "last_page": {
+                                            "type": "integer",
+                                            "example": 20
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Ingredients"
+                ],
+                "summary": "Create a new ingredient",
+                "operationId": "0d674a4f6ca04a7604deddd5ffc1d160",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "source",
+                                    "name",
+                                    "default_amount",
+                                    "default_amount_unit_id"
+                                ],
+                                "properties": {
+                                    "source": {
+                                        "type": "string",
+                                        "example": "USDA"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Broccoli, raw"
+                                    },
+                                    "external_id": {
+                                        "type": "string",
+                                        "example": "321360",
+                                        "nullable": true
+                                    },
+                                    "class": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "slug": {
+                                        "type": "string",
+                                        "example": "broccoli-raw",
+                                        "nullable": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "default_amount": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 100
+                                    },
+                                    "default_amount_unit_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "brand_id": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Ingredient"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/ingredients/{ingredient}": {
+            "get": {
+                "tags": [
+                    "Ingredients"
+                ],
+                "summary": "Get a single ingredient with all relationships",
+                "operationId": "b5bdb82e230552aabcf49f77306133a5",
+                "parameters": [
+                    {
+                        "name": "ingredient",
+                        "in": "path",
+                        "description": "Ingredient ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Ingredient resource",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Ingredient"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Ingredients"
+                ],
+                "summary": "Update an ingredient",
+                "operationId": "ce3cdee317f0ef1b5d9a3cbc18b101ca",
+                "parameters": [
+                    {
+                        "name": "ingredient",
+                        "in": "path",
+                        "description": "Ingredient ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "source": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "external_id": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "class": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "slug": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "default_amount": {
+                                        "type": "number",
+                                        "format": "float"
+                                    },
+                                    "default_amount_unit_id": {
+                                        "type": "integer"
+                                    },
+                                    "brand_id": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Ingredient"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Ingredients"
+                ],
+                "summary": "Soft-delete an ingredient",
+                "operationId": "b519f81034a5ac4cdff57d149fd05c00",
+                "parameters": [
+                    {
+                        "name": "ingredient",
+                        "in": "path",
+                        "description": "Ingredient ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Deleted"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/ingredients/search": {
+            "post": {
+                "tags": [
+                    "Ingredients"
+                ],
+                "summary": "Full-text search ingredients",
+                "operationId": "2fae9b559b45f1504e94f06123bfe98c",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "query"
+                                ],
+                                "properties": {
+                                    "query": {
+                                        "type": "string",
+                                        "example": "broccoli"
+                                    },
+                                    "page": {
+                                        "type": "integer",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Search results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "hits": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Ingredient"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "example": 3
+                                        },
+                                        "page": {
+                                            "type": "integer",
+                                            "example": 1
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/auth/login": {
+            "post": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Get OAuth2 redirect URI",
+                "operationId": "929538638b39fce3e5d2c142898267b5",
+                "responses": {
+                    "200": {
+                        "description": "Redirect URI",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "redirect_uri": {
+                                            "type": "string",
+                                            "example": "https://auth.example.com/oauth/authorize?..."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/auth/validate-access-token": {
+            "get": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Validate a bearer access token",
+                "operationId": "cd2c295b52742448174746ee7ea4bbca",
+                "responses": {
+                    "200": {
+                        "description": "Token is valid"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "503": {
+                        "description": "Auth service unavailable"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/auth/logout": {
+            "post": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Logout and invalidate tokens",
+                "operationId": "f1edef7f79a0461455ab182363b1fd37",
+                "responses": {
+                    "200": {
+                        "description": "Logged out successfully"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "503": {
+                        "description": "Auth service unavailable"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/nutrient-tags": {
+            "get": {
+                "tags": [
+                    "NutrientTags"
+                ],
+                "summary": "List nutrient tags (paginated)",
+                "operationId": "9773be54d8961d8895e9fdf1ac602b5a",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Paginated list of nutrient tags",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/NutrientTag"
+                                            }
+                                        },
+                                        "current_page": {
+                                            "type": "integer"
+                                        },
+                                        "total": {
+                                            "type": "integer"
+                                        },
+                                        "per_page": {
+                                            "type": "integer"
+                                        },
+                                        "last_page": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "NutrientTags"
+                ],
+                "summary": "Create a new nutrient tag",
+                "operationId": "9434cc8a6e8157bef51aabfbaebb74e8",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "slug"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Fat-soluble"
+                                    },
+                                    "slug": {
+                                        "type": "string",
+                                        "example": "fat-soluble"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NutrientTag"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/nutrient-tags/{nutrientTag}": {
+            "get": {
+                "tags": [
+                    "NutrientTags"
+                ],
+                "summary": "Get a single nutrient tag",
+                "operationId": "bf048e643b7f1f889e49b0b430f8354c",
+                "parameters": [
+                    {
+                        "name": "nutrientTag",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "NutrientTag resource",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NutrientTag"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "NutrientTags"
+                ],
+                "summary": "Update a nutrient tag",
+                "operationId": "291b664a6e9ce401111681d9fc436fd9",
+                "parameters": [
+                    {
+                        "name": "nutrientTag",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "slug": {
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NutrientTag"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "NutrientTags"
+                ],
+                "summary": "Delete a nutrient tag",
+                "operationId": "a2173965ba2ab3c23e379619e269df3f",
+                "parameters": [
+                    {
+                        "name": "nutrientTag",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Deleted"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/nutrients/{nutrient}/tags": {
+            "post": {
+                "tags": [
+                    "NutrientTags"
+                ],
+                "summary": "Attach a tag to a nutrient",
+                "operationId": "2992197104d17d81e0d67d7165fe7008",
+                "parameters": [
+                    {
+                        "name": "nutrient",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "tag_id"
+                                ],
+                                "properties": {
+                                    "tag_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated tag list",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/NutrientTag"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "NutrientTags"
+                ],
+                "summary": "Detach all tags from a nutrient",
+                "operationId": "eb8fe5a39920cd9cbe4050e02e3b5e25",
+                "parameters": [
+                    {
+                        "name": "nutrient",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "All tags detached"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/nutrients/{nutrient}/tags/{tag}": {
+            "delete": {
+                "tags": [
+                    "NutrientTags"
+                ],
+                "summary": "Detach a specific tag from a nutrient",
+                "operationId": "2be0de208a01c98c51fe7d2ca3484aa1",
+                "parameters": [
+                    {
+                        "name": "nutrient",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "tag",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Detached"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/nutrients": {
+            "get": {
+                "tags": [
+                    "Nutrients"
+                ],
+                "summary": "List nutrients (paginated)",
+                "operationId": "59153af12457b12724a580787f70c96b",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Paginated list of nutrients",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Nutrient"
+                                            }
+                                        },
+                                        "current_page": {
+                                            "type": "integer",
+                                            "example": 1
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "example": 100
+                                        },
+                                        "per_page": {
+                                            "type": "integer",
+                                            "example": 25
+                                        },
+                                        "last_page": {
+                                            "type": "integer",
+                                            "example": 4
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Nutrients"
+                ],
+                "summary": "Create a new nutrient",
+                "operationId": "606e7a95222294837bdd4c6e76780226",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "source_id",
+                                    "name"
+                                ],
+                                "properties": {
+                                    "source_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Vitamin C"
+                                    },
+                                    "external_id": {
+                                        "type": "string",
+                                        "example": "1004",
+                                        "nullable": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "parent_id": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    },
+                                    "slug": {
+                                        "type": "string",
+                                        "example": "vitamin-c",
+                                        "nullable": true
+                                    },
+                                    "canonical_unit_id": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    },
+                                    "iu_to_canonical_factor": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "nullable": true
+                                    },
+                                    "is_label_standard": {
+                                        "type": "boolean",
+                                        "example": true
+                                    },
+                                    "display_order": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Nutrient"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/nutrients/{nutrient}": {
+            "get": {
+                "tags": [
+                    "Nutrients"
+                ],
+                "summary": "Get a single nutrient with all relationships",
+                "operationId": "bedeae6923057eede2de724c1539b771",
+                "parameters": [
+                    {
+                        "name": "nutrient",
+                        "in": "path",
+                        "description": "Nutrient ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Nutrient resource",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Nutrient"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Nutrients"
+                ],
+                "summary": "Update a nutrient",
+                "operationId": "29dd63bc25f96eb426c742025fa497a0",
+                "parameters": [
+                    {
+                        "name": "nutrient",
+                        "in": "path",
+                        "description": "Nutrient ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "source_id": {
+                                        "type": "integer"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "external_id": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "parent_id": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    },
+                                    "slug": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "canonical_unit_id": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    },
+                                    "iu_to_canonical_factor": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "nullable": true
+                                    },
+                                    "is_label_standard": {
+                                        "type": "boolean"
+                                    },
+                                    "display_order": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Nutrient"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Nutrients"
+                ],
+                "summary": "Soft-delete a nutrient",
+                "operationId": "85ab7fd539285e785253af7299131755",
+                "parameters": [
+                    {
+                        "name": "nutrient",
+                        "in": "path",
+                        "description": "Nutrient ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Deleted"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/nutrients/search": {
+            "post": {
+                "tags": [
+                    "Nutrients"
+                ],
+                "summary": "Full-text search nutrients",
+                "operationId": "88f86f852f92e5f4751fd9e29d7f124c",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "query"
+                                ],
+                                "properties": {
+                                    "query": {
+                                        "type": "string",
+                                        "example": "vitamin c"
+                                    },
+                                    "page": {
+                                        "type": "integer",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Search results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "hits": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Nutrient"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "example": 5
+                                        },
+                                        "page": {
+                                            "type": "integer",
+                                            "example": 1
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/search": {
+            "post": {
+                "tags": [
+                    "Search"
+                ],
+                "summary": "Full-text search across a resource index with caching",
+                "operationId": "06b31678f7e6f0ba423b15e1055d7f5d",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "query",
+                                    "index"
+                                ],
+                                "properties": {
+                                    "query": {
+                                        "type": "string",
+                                        "example": "broccoli"
+                                    },
+                                    "index": {
+                                        "description": "Search index name (e.g. ingredients, nutrients)",
+                                        "type": "string",
+                                        "example": "ingredients"
+                                    },
+                                    "page": {
+                                        "type": "integer",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Search results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "hits": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "example": 10
+                                        },
+                                        "page": {
+                                            "type": "integer",
+                                            "example": 1
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    },
+                    "502": {
+                        "description": "Search service unavailable"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/sources": {
+            "get": {
+                "tags": [
+                    "Sources"
+                ],
+                "summary": "List sources (paginated)",
+                "operationId": "0d4b9d4235ca94b03bc00fc5d9d47dc5",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Paginated list of sources",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Source"
+                                            }
+                                        },
+                                        "current_page": {
+                                            "type": "integer"
+                                        },
+                                        "total": {
+                                            "type": "integer"
+                                        },
+                                        "per_page": {
+                                            "type": "integer"
+                                        },
+                                        "last_page": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Sources"
+                ],
+                "summary": "Create a new source",
+                "operationId": "c8b05c203ddba0cbf523e393fef7f5f8",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "slug"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "USDA FoodData Central"
+                                    },
+                                    "slug": {
+                                        "type": "string",
+                                        "example": "usda-fooddata-central"
+                                    },
+                                    "url": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Source"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/sources/{source}": {
+            "get": {
+                "tags": [
+                    "Sources"
+                ],
+                "summary": "Get a single source",
+                "operationId": "75be94f315ccb4a8b5f045374448936a",
+                "parameters": [
+                    {
+                        "name": "source",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Source resource",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Source"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Sources"
+                ],
+                "summary": "Update a source",
+                "operationId": "5caad678d15a4fcf2ceb96991b878ec4",
+                "parameters": [
+                    {
+                        "name": "source",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "slug": {
+                                        "type": "string"
+                                    },
+                                    "url": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Source"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Sources"
+                ],
+                "summary": "Delete a source",
+                "operationId": "29f75a6a578fedf53ed9d96d6894ec87",
+                "parameters": [
+                    {
+                        "name": "source",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Deleted"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/units": {
+            "get": {
+                "tags": [
+                    "Units"
+                ],
+                "summary": "List units (paginated)",
+                "operationId": "295b451e7075d6052290154e2042a1e5",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Paginated list of units",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Unit"
+                                            }
+                                        },
+                                        "current_page": {
+                                            "type": "integer"
+                                        },
+                                        "total": {
+                                            "type": "integer"
+                                        },
+                                        "per_page": {
+                                            "type": "integer"
+                                        },
+                                        "last_page": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Create a new unit",
+                "operationId": "aad258e5671f50e08f4e544f7bed01be",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "abbreviation"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Gram"
+                                    },
+                                    "abbreviation": {
+                                        "type": "string",
+                                        "example": "g"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "example": "mass",
+                                        "nullable": true
+                                    },
+                                    "to_base_factor": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 1,
+                                        "nullable": true
+                                    },
+                                    "base_unit_id": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Unit"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        },
+        "/api/units/{unit}": {
+            "get": {
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Get a single unit with base and derived units",
+                "operationId": "312c08234b596a15489b92207251c169",
+                "parameters": [
+                    {
+                        "name": "unit",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Unit resource",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Unit"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Update a unit",
+                "operationId": "1b15aec7644e432e985b579d05e432b7",
+                "parameters": [
+                    {
+                        "name": "unit",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "abbreviation": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "to_base_factor": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "nullable": true
+                                    },
+                                    "base_unit_id": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Unit"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Units"
+                ],
+                "summary": "Delete a unit",
+                "operationId": "5dd737d967c4ad71f456271b85ed797e",
+                "parameters": [
+                    {
+                        "name": "unit",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Deleted"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "frontend": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Brand": {
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Acme Foods"
+                    },
+                    "slug": {
+                        "type": "string",
+                        "example": "acme-foods"
+                    },
+                    "owner": {
+                        "type": "string",
+                        "example": "Acme Corp",
+                        "nullable": true
+                    },
+                    "country": {
+                        "type": "string",
+                        "example": "US",
+                        "nullable": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": null,
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "IngredientCategory": {
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Vegetables"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "IngredientNutrientPivot": {
+                "properties": {
+                    "amount": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 10.5,
+                        "nullable": true
+                    },
+                    "amount_unit": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/Unit"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "IngredientNutritionFact": {
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "category": {
+                        "type": "string",
+                        "example": "Vitamins",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Vitamin C"
+                    },
+                    "amount": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 52,
+                        "nullable": true
+                    },
+                    "unit": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/Unit"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "Ingredient": {
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "external_id": {
+                        "type": "string",
+                        "example": "321360",
+                        "nullable": true
+                    },
+                    "source": {
+                        "type": "string",
+                        "example": "USDA",
+                        "nullable": true
+                    },
+                    "class": {
+                        "type": "string",
+                        "example": "FoodItem",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Broccoli, raw"
+                    },
+                    "slug": {
+                        "type": "string",
+                        "example": "broccoli-raw"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": null,
+                        "nullable": true
+                    },
+                    "default_amount": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 100,
+                        "nullable": true
+                    },
+                    "sync_status": {
+                        "type": "string",
+                        "example": "synced"
+                    },
+                    "brand": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/Brand"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "default_amount_unit": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/Unit"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "nutrients": {
+                        "type": "array",
+                        "items": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/Nutrient"
+                                },
+                                {
+                                    "properties": {
+                                        "pivot": {
+                                            "$ref": "#/components/schemas/IngredientNutrientPivot"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        "nullable": true
+                    },
+                    "nutrition_facts": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/IngredientNutritionFact"
+                        },
+                        "nullable": true
+                    },
+                    "categories": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/IngredientCategory"
+                        },
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "deleted_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "Nutrient": {
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "external_id": {
+                        "type": "string",
+                        "example": "1004",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Vitamin C"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": null,
+                        "nullable": true
+                    },
+                    "slug": {
+                        "type": "string",
+                        "example": "vitamin-c"
+                    },
+                    "iu_to_canonical_factor": {
+                        "type": "number",
+                        "format": "float",
+                        "example": null,
+                        "nullable": true
+                    },
+                    "is_label_standard": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "display_order": {
+                        "type": "integer",
+                        "example": 10,
+                        "nullable": true
+                    },
+                    "sync_status": {
+                        "type": "string",
+                        "example": "synced"
+                    },
+                    "source": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/Source"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "canonical_unit": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/Unit"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "parent": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/Nutrient"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "children": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Nutrient"
+                        }
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/NutrientTag"
+                        }
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "deleted_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "NutrientTag": {
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Fat-soluble"
+                    },
+                    "slug": {
+                        "type": "string",
+                        "example": "fat-soluble"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": null,
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "Source": {
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "USDA FoodData Central"
+                    },
+                    "slug": {
+                        "type": "string",
+                        "example": "usda-fooddata-central"
+                    },
+                    "url": {
+                        "type": "string",
+                        "example": "https://fdc.nal.usda.gov",
+                        "nullable": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": null,
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "Unit": {
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Gram"
+                    },
+                    "abbreviation": {
+                        "type": "string",
+                        "example": "g"
+                    },
+                    "type": {
+                        "type": "string",
+                        "example": "mass",
+                        "nullable": true
+                    },
+                    "to_base_factor": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 1,
+                        "nullable": true
+                    },
+                    "base_unit_id": {
+                        "type": "integer",
+                        "example": null,
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "securitySchemes": {
+            "frontend": {
+                "type": "http",
+                "description": "Bearer token obtained from POST /api/auth/login. Also requires X-Refresh-Token, X-Application-Name, and X-Client-Url headers on every request.",
+                "scheme": "bearer"
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "Agent",
+            "description": "Agent"
+        },
+        {
+            "name": "Brands",
+            "description": "Brands"
+        },
+        {
+            "name": "IngredientNutrients",
+            "description": "IngredientNutrients"
+        },
+        {
+            "name": "Ingredients",
+            "description": "Ingredients"
+        },
+        {
+            "name": "Auth",
+            "description": "Auth"
+        },
+        {
+            "name": "NutrientTags",
+            "description": "NutrientTags"
+        },
+        {
+            "name": "Nutrients",
+            "description": "Nutrients"
+        },
+        {
+            "name": "Search",
+            "description": "Search"
+        },
+        {
+            "name": "Sources",
+            "description": "Sources"
+        },
+        {
+            "name": "Units",
+            "description": "Units"
+        }
+    ]
+}

--- a/tests/Feature/OpenApi/OpenApiSpecTest.php
+++ b/tests/Feature/OpenApi/OpenApiSpecTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\OpenApi;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class OpenApiSpecTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Artisan::call('l5-swagger:generate');
+    }
+
+    // -------------------------------------------------------------------------
+    // Endpoint availability
+    // -------------------------------------------------------------------------
+
+    public function test_spec_endpoint_returns_ok(): void
+    {
+        $this->get('/api/docs/openapi.json')->assertOk();
+    }
+
+    // -------------------------------------------------------------------------
+    // OpenAPI structure
+    // -------------------------------------------------------------------------
+
+    public function test_spec_is_openapi_3(): void
+    {
+        $json = $this->get('/api/docs/openapi.json')->json();
+
+        $this->assertStringStartsWith('3.', $json['openapi'] ?? '');
+    }
+
+    public function test_spec_has_nutrients_api_title(): void
+    {
+        $json = $this->get('/api/docs/openapi.json')->json();
+
+        $this->assertSame('Nutrients API', $json['info']['title'] ?? null);
+    }
+
+    public function test_spec_version_matches_app_config(): void
+    {
+        $json = $this->get('/api/docs/openapi.json')->json();
+
+        $this->assertSame(config('app.api_version'), $json['info']['version'] ?? null);
+    }
+
+    // -------------------------------------------------------------------------
+    // Paths
+    // -------------------------------------------------------------------------
+
+    public function test_spec_contains_key_resource_paths(): void
+    {
+        $json  = $this->get('/api/docs/openapi.json')->json();
+        $paths = array_keys($json['paths'] ?? []);
+
+        $this->assertContains('/api/nutrients', $paths);
+        $this->assertContains('/api/ingredients', $paths);
+        $this->assertContains('/api/auth/login', $paths);
+        $this->assertContains('/api/agent', $paths);
+    }
+
+    // -------------------------------------------------------------------------
+    // Security
+    // -------------------------------------------------------------------------
+
+    public function test_spec_declares_frontend_bearer_security_scheme(): void
+    {
+        $json = $this->get('/api/docs/openapi.json')->json();
+
+        $this->assertArrayHasKey('frontend', $json['components']['securitySchemes'] ?? []);
+        $this->assertSame('http', $json['components']['securitySchemes']['frontend']['type'] ?? null);
+        $this->assertSame('bearer', $json['components']['securitySchemes']['frontend']['scheme'] ?? null);
+    }
+}


### PR DESCRIPTION
Installs darkaonline/l5-swagger and doctrine/annotations, wires the spec endpoint at GET /api/docs/openapi.json, and annotates all controllers and API resources using PHP 8 native attributes (OpenApi\Attributes). Adds an OpenApiSpecTest suite that validates the spec structure, paths, and security scheme on every test run.