### PR TITLE
feat: add CanonicalNutrientsSeeder with 57 leaf nutrients

### DIFF
--- a/database/seeders/CanonicalNutrientsSeeder.php
+++ b/database/seeders/CanonicalNutrientsSeeder.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Nutrient;
+use App\Models\Unit;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class CanonicalNutrientsSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    private array $units = [];
+
+    public function run(): void
+    {
+        $this->units = Unit::whereIn('abbreviation', ['kcal', 'g', 'mg', 'µg'])
+            ->get()
+            ->keyBy('abbreviation')
+            ->all();
+
+        // ── Category node metadata ────────────────────────────────────────────────
+        $this->updateCategory('Fat',           true,  35);
+        $this->updateCategory('Carbohydrates', true,  85);
+
+        // ── Macronutrients ────────────────────────────────────────────────────────
+        $macro = $this->findParent('Macronutrients');
+        $this->seed($macro, 'Energy',  'kcal', true,  10);
+        $this->seed($macro, 'Protein', 'g',    true,  20);
+        $this->seed($macro, 'Water',   'g',    false, 30);
+
+        // ── Fat ───────────────────────────────────────────────────────────────────
+        $fat = $this->findParent('Fat');
+        $this->seed($fat, 'Saturated Fat', 'g',  true,  40);
+        $this->seed($fat, 'Trans Fat',     'g',  true,  50);
+        $this->seed($fat, 'Cholesterol',   'mg', true,  60);
+
+        $unsat = $this->findParent('Unsaturated Fat');
+        $this->seed($unsat, 'Monounsaturated Fat', 'g', false, 70);
+        $this->seed($unsat, 'Polyunsaturated Fat', 'g', false, 80);
+
+        // ── Carbohydrates ─────────────────────────────────────────────────────────
+        $carbs = $this->findParent('Carbohydrates');
+        $this->seed($carbs, 'Dietary Fiber', 'g', true,  90);
+        $this->seed($carbs, 'Sugars',        'g', true,  100);
+
+        // ── Fat-soluble Vitamins ──────────────────────────────────────────────────
+        $fatSol = $this->findParent('Fat-soluble Vitamins');
+        $this->seed($fatSol, 'Vitamin A', 'µg', true, 200, 0.3);
+        $this->seed($fatSol, 'Vitamin D', 'µg', true, 210, 0.025);
+        $this->seed($fatSol, 'Vitamin E', 'mg', true, 220, 0.67);
+        $this->seed($fatSol, 'Vitamin K', 'µg', true, 230);
+
+        // ── Water-soluble Vitamins ────────────────────────────────────────────────
+        $waterSol = $this->findParent('Water-soluble Vitamins');
+        $this->seed($waterSol, 'Vitamin C',   'mg', true, 240);
+        $this->seed($waterSol, 'Vitamin B1',  'mg', true, 250);
+        $this->seed($waterSol, 'Vitamin B2',  'mg', true, 260);
+        $this->seed($waterSol, 'Vitamin B3',  'mg', true, 270);
+        $this->seed($waterSol, 'Vitamin B5',  'mg', true, 280);
+        $this->seed($waterSol, 'Vitamin B6',  'mg', true, 290);
+        $this->seed($waterSol, 'Vitamin B7',  'µg', true, 300);
+        $this->seed($waterSol, 'Vitamin B9',  'µg', true, 310);
+        $this->seed($waterSol, 'Vitamin B12', 'µg', true, 320);
+
+        // ── Macrominerals ─────────────────────────────────────────────────────────
+        $macro_min = $this->findParent('Macrominerals');
+        $this->seed($macro_min, 'Calcium',    'mg', true,  400);
+        $this->seed($macro_min, 'Phosphorus', 'mg', false, 410);
+        $this->seed($macro_min, 'Magnesium',  'mg', false, 420);
+        $this->seed($macro_min, 'Sodium',     'mg', true,  430);
+        $this->seed($macro_min, 'Potassium',  'mg', true,  440);
+        $this->seed($macro_min, 'Chloride',   'mg', false, 450);
+
+        // ── Trace Minerals ────────────────────────────────────────────────────────
+        $trace = $this->findParent('Trace Minerals');
+        $this->seed($trace, 'Iron',       'mg', true,  500);
+        $this->seed($trace, 'Zinc',       'mg', false, 510);
+        $this->seed($trace, 'Copper',     'mg', false, 520);
+        $this->seed($trace, 'Manganese',  'mg', false, 530);
+        $this->seed($trace, 'Selenium',   'µg', false, 540);
+        $this->seed($trace, 'Iodine',     'µg', false, 550);
+        $this->seed($trace, 'Chromium',   'µg', false, 560);
+        $this->seed($trace, 'Molybdenum', 'µg', false, 570);
+        $this->seed($trace, 'Fluoride',   'mg', false, 580);
+
+        // ── Omega-3 Fatty Acids ───────────────────────────────────────────────────
+        $omega3 = $this->findParent('Omega-3 Fatty Acids');
+        $this->seed($omega3, 'Alpha-Linolenic Acid (ALA)',  'g', false, 600);
+        $this->seed($omega3, 'Eicosapentaenoic Acid (EPA)', 'g', false, 610);
+        $this->seed($omega3, 'Docosahexaenoic Acid (DHA)',  'g', false, 620);
+
+        // ── Omega-6 Fatty Acids ───────────────────────────────────────────────────
+        $omega6 = $this->findParent('Omega-6 Fatty Acids');
+        $this->seed($omega6, 'Linoleic Acid (LA)',         'g', false, 630);
+        $this->seed($omega6, 'Arachidonic Acid (AA)',      'g', false, 640);
+        $this->seed($omega6, 'Gamma-Linolenic Acid (GLA)', 'g', false, 650);
+
+        // ── Omega-9 Fatty Acids ───────────────────────────────────────────────────
+        $omega9 = $this->findParent('Omega-9 Fatty Acids');
+        $this->seed($omega9, 'Oleic Acid', 'g', false, 660);
+
+        // ── Essential Amino Acids ─────────────────────────────────────────────────
+        $essential = $this->findParent('Essential Amino Acids');
+        $this->seed($essential, 'Histidine',     'g', false, 700);
+        $this->seed($essential, 'Isoleucine',    'g', false, 710);
+        $this->seed($essential, 'Leucine',       'g', false, 720);
+        $this->seed($essential, 'Lysine',        'g', false, 730);
+        $this->seed($essential, 'Methionine',    'g', false, 740);
+        $this->seed($essential, 'Phenylalanine', 'g', false, 750);
+        $this->seed($essential, 'Threonine',     'g', false, 760);
+        $this->seed($essential, 'Tryptophan',    'g', false, 770);
+        $this->seed($essential, 'Valine',        'g', false, 780);
+
+        // ── Non-essential Amino Acids ─────────────────────────────────────────────
+        $nonEssential = $this->findParent('Non-essential Amino Acids');
+        $this->seed($nonEssential, 'Alanine',       'g', false, 800);
+        $this->seed($nonEssential, 'Arginine',      'g', false, 810);
+        $this->seed($nonEssential, 'Asparagine',    'g', false, 820);
+        $this->seed($nonEssential, 'Aspartic Acid', 'g', false, 830);
+        $this->seed($nonEssential, 'Cysteine',      'g', false, 840);
+        $this->seed($nonEssential, 'Glutamic Acid', 'g', false, 850);
+        $this->seed($nonEssential, 'Glutamine',     'g', false, 860);
+        $this->seed($nonEssential, 'Glycine',       'g', false, 870);
+        $this->seed($nonEssential, 'Proline',       'g', false, 880);
+        $this->seed($nonEssential, 'Serine',        'g', false, 890);
+        $this->seed($nonEssential, 'Tyrosine',      'g', false, 900);
+    }
+
+    private function seed(
+        Nutrient $parent,
+        string $name,
+        string $unitAbbr,
+        bool $isLabelStandard,
+        ?int $displayOrder = null,
+        ?float $iuFactor = null,
+    ): Nutrient {
+        $unitId = $this->units[$unitAbbr]->id ?? null;
+
+        $nutrient = Nutrient::where('name', $name)
+            ->whereDoesntHave('sourceMappings')
+            ->first();
+
+        if ($nutrient) {
+            $nutrient->update([
+                'parent_id'              => $parent->id,
+                'canonical_unit_id'      => $unitId,
+                'is_label_standard'      => $isLabelStandard,
+                'display_order'          => $displayOrder,
+                'iu_to_canonical_factor' => $iuFactor,
+            ]);
+
+            return $nutrient;
+        }
+
+        return Nutrient::create([
+            'name'                   => $name,
+            'parent_id'              => $parent->id,
+            'canonical_unit_id'      => $unitId,
+            'is_label_standard'      => $isLabelStandard,
+            'display_order'          => $displayOrder,
+            'iu_to_canonical_factor' => $iuFactor,
+        ]);
+    }
+
+    private function updateCategory(string $name, bool $isLabelStandard, ?int $displayOrder): void
+    {
+        Nutrient::where('name', $name)
+            ->whereDoesntHave('sourceMappings')
+            ->update([
+                'is_label_standard' => $isLabelStandard,
+                'display_order'     => $displayOrder,
+            ]);
+    }
+
+    private function findParent(string $name): Nutrient
+    {
+        return Nutrient::where('name', $name)
+            ->whereDoesntHave('sourceMappings')
+            ->firstOrFail();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,7 @@ class DatabaseSeeder extends Seeder
             UnitConversionFactorSeeder::class,
             SourcesTableSeeder::class,
             NutrientsTableSeeder::class,
+            CanonicalNutrientsSeeder::class,
         ]);
     }
 }

--- a/tests/Feature/Seeders/CanonicalNutrientsSeederTest.php
+++ b/tests/Feature/Seeders/CanonicalNutrientsSeederTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature\Seeders;
+
+use App\Models\Nutrient;
+use App\Models\NutrientSourcePivot;
+use App\Models\Source;
+use Database\Seeders\CanonicalNutrientsSeeder;
+use Database\Seeders\DatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class CanonicalNutrientsSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+        $this->seed(DatabaseSeeder::class);
+    }
+
+    public function test_hierarchy_is_correct(): void
+    {
+        $this->assertParent('Energy',              'Macronutrients');
+        $this->assertParent('Vitamin B1',          'Water-soluble Vitamins');
+        $this->assertParent('Monounsaturated Fat', 'Unsaturated Fat');
+        $this->assertParent('Polyunsaturated Fat', 'Unsaturated Fat');
+        $this->assertParent('Iron',                'Trace Minerals');
+        $this->assertParent('Glycine',             'Non-essential Amino Acids');
+        $this->assertParent('Alpha-Linolenic Acid (ALA)', 'Omega-3 Fatty Acids');
+    }
+
+    public function test_canonical_units_are_assigned_correctly(): void
+    {
+        $this->assertUnit('Energy',   'kcal');
+        $this->assertUnit('Protein',  'g');
+        $this->assertUnit('Calcium',  'mg');
+        $this->assertUnit('Selenium', 'µg');
+    }
+
+    public function test_iu_conversion_factors_are_set(): void
+    {
+        $this->assertEquals(0.3,    $this->canonical('Vitamin A')->iu_to_canonical_factor);
+        $this->assertEquals(0.025,  $this->canonical('Vitamin D')->iu_to_canonical_factor);
+        $this->assertEquals(0.67,   $this->canonical('Vitamin E')->iu_to_canonical_factor);
+        $this->assertNull(          $this->canonical('Vitamin C')->iu_to_canonical_factor);
+    }
+
+    public function test_is_label_standard_set_correctly(): void
+    {
+        $this->assertTrue($this->canonical('Vitamin C')->is_label_standard);
+        $this->assertTrue($this->canonical('Vitamin B12')->is_label_standard);
+        $this->assertTrue($this->canonical('Iron')->is_label_standard);
+        $this->assertFalse($this->canonical('Glycine')->is_label_standard);
+        $this->assertFalse($this->canonical('Water')->is_label_standard);
+    }
+
+    public function test_display_order_set_correctly(): void
+    {
+        $this->assertEquals(10,  $this->canonical('Energy')->display_order);
+        $this->assertEquals(240, $this->canonical('Vitamin C')->display_order);
+        $this->assertEquals(500, $this->canonical('Iron')->display_order);
+        $this->assertEquals(780, $this->canonical('Valine')->display_order);
+    }
+
+    public function test_updates_category_node_metadata(): void
+    {
+        $fat  = $this->canonical('Fat');
+        $carbs = $this->canonical('Carbohydrates');
+
+        $this->assertTrue($fat->is_label_standard);
+        $this->assertEquals(35, $fat->display_order);
+
+        $this->assertTrue($carbs->is_label_standard);
+        $this->assertEquals(85, $carbs->display_order);
+    }
+
+    public function test_canonical_nutrients_have_no_source_mappings(): void
+    {
+        $names = ['Energy', 'Vitamin C', 'Calcium', 'Leucine', 'Alpha-Linolenic Acid (ALA)'];
+
+        foreach ($names as $name) {
+            $this->assertEquals(
+                0,
+                $this->canonical($name)->sourceMappings()->count(),
+                "Expected {$name} to have no source mappings"
+            );
+        }
+    }
+
+    public function test_is_idempotent(): void
+    {
+        $countBefore = Nutrient::whereDoesntHave('sourceMappings')->count();
+
+        $this->seed(CanonicalNutrientsSeeder::class);
+
+        $this->assertEquals($countBefore, Nutrient::whereDoesntHave('sourceMappings')->count());
+        $this->assertEquals(0.3, $this->canonical('Vitamin A')->iu_to_canonical_factor);
+        $this->assertEquals(10,  $this->canonical('Energy')->display_order);
+    }
+
+    public function test_does_not_affect_nutrients_with_source_mappings(): void
+    {
+        $source = Source::factory()->create();
+
+        $usda = Nutrient::factory()->create(['name' => 'Protein']);
+        NutrientSourcePivot::create([
+            'nutrient_id' => $usda->id,
+            'source_id'   => $source->id,
+            'external_id' => '1003',
+        ]);
+
+        $originalParentId = $usda->parent_id;
+
+        $this->seed(CanonicalNutrientsSeeder::class);
+
+        $usda->refresh();
+        $this->assertEquals($originalParentId, $usda->parent_id);
+        $this->assertNull($usda->canonical_unit_id);
+    }
+
+    private function canonical(string $name): Nutrient
+    {
+        return Nutrient::where('name', $name)
+            ->whereDoesntHave('sourceMappings')
+            ->firstOrFail();
+    }
+
+    private function assertParent(string $name, string $expectedParent): void
+    {
+        $nutrient = $this->canonical($name);
+        $this->assertNotNull($nutrient->parent_id, "Expected {$name} to have a parent");
+        $this->assertEquals(
+            $expectedParent,
+            $nutrient->parent->name,
+            "Expected {$name} parent to be {$expectedParent}"
+        );
+    }
+
+    private function assertUnit(string $name, string $abbreviation): void
+    {
+        $nutrient = $this->canonical($name);
+        $this->assertNotNull($nutrient->canonical_unit_id, "Expected {$name} to have a canonical unit");
+        $this->assertEquals(
+            $abbreviation,
+            $nutrient->canonicalUnit->abbreviation,
+            "Expected {$name} canonical unit to be {$abbreviation}"
+        );
+    }
+}


### PR DESCRIPTION
Seeds the full canonical nutrient taxonomy — macronutrients, fat, carbohydrates, fat/water-soluble vitamins, macro/trace minerals, omega fatty acids, and essential/non-essential amino acids — with canonical units, is_label_standard flags, display order, and IU conversion factors for vitamins A, D, and E. Idempotent: finds existing canonical nutrients by name and updates metadata rather than re-creating. Wired into DatabaseSeeder after NutrientsTableSeeder.